### PR TITLE
Install and configure Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+# This is a `.prettierignore` file.
+# It inherits from `.gitignore` automatically.
+# Reference: https://prettier.io/docs/en/ignore
+
+# Git does not ignore the following file, but we do want Prettier to ignore it:
+/.vscode/extensions.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,5 +2,9 @@
 # It inherits from `.gitignore` automatically.
 # Reference: https://prettier.io/docs/en/ignore
 
-# Git does not ignore the following file, but we do want Prettier to ignore it:
+# Ignore Android code (e.g. Java) and iOS code (e.g. Swift).
+/android
+/ios
+
+# Ignore VS Code extensions file.
 /.vscode/extensions.json

--- a/README.md
+++ b/README.md
@@ -51,3 +51,28 @@ ionic cap run ios --livereload --external
 ```
 
 This may take a minute or so to start initially. You should see the message `Deploying App.app to <uuid>` written to the console and then the simulator window should open.
+
+### Format code
+
+We use [Prettier](https://prettier.io/) to ensure the files in this repository are formatted the way we want.
+
+You can use it like this:
+
+```shell
+# Check whether any files are not formatted.
+npx run format:check
+
+# Format all files.
+npx run format
+```
+
+The `.prettierignore` file tells Prettier which files we want it to 
+[ignore](https://prettier.io/docs/en/ignore#ignoring-files-prettierignore) (i.e. to _not_ format).
+
+> The `.prettierignore` file automatically inherits from the `.gitignore` file.
+
+The `prettier.config.js` file can be used to override Prettier's
+default [configuration](https://prettier.io/docs/en/configuration).
+
+> Also, the presence of the file signifies to [code editors](https://prettier.io/docs/en/editors)
+that this project uses Prettier; which may influence some features of the editor.

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "eslint": "^8.35.0",
         "eslint-plugin-react": "^7.32.2",
         "jsdom": "^22.1.0",
+        "prettier": "3.2.1",
         "terser": "^5.4.0",
         "typescript": "^5.1.6",
         "vite": "^5.0.0",
@@ -8414,6 +8415,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.1.tgz",
+      "integrity": "sha512-qSUWshj1IobVbKc226Gw2pync27t0Kf0EdufZa9j7uBSJay1CC+B3K5lAAZoqgX3ASiKuWsk6OmzKRetXNObWg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "format": "prettier . --write",
+    "format:check": "prettier . --check",
     "preview": "vite preview",
     "test.e2e": "cypress run",
     "test.unit": "vitest",
@@ -45,6 +47,7 @@
     "eslint": "^8.35.0",
     "eslint-plugin-react": "^7.32.2",
     "jsdom": "^22.1.0",
+    "prettier": "3.2.1",
     "terser": "^5.4.0",
     "typescript": "^5.1.6",
     "vite": "^5.0.0",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,6 @@
+/**
+ * This is a Prettier configuration file.
+ *
+ * Reference: https://prettier.io/docs/en/configuration
+ */
+export default {}


### PR DESCRIPTION
### Summary of changes

- Designate `prettier` as a development dependency
- Create `.prettierignore` and `prettier.config.js` files
- Configure Prettier to ignore the VS Code Extensions JSON file and the `ios` and `android` folders
- Document the usage of Prettier via `npm run format` and `npm run format:check`

### Screenshots

You can configure PyCharm to use Prettier, like this:

![image](https://github.com/microbiomedata/nmdc-field-notes/assets/134325062/134b5f9b-c970-45bf-b553-9b81b26f86e5)
