### PR TITLE
Implement `404.html` page that redirects to domain root

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>NMDC Field Notes</title>
+  </head>
+  <body>
+    <script>
+      /**
+       * Navigate the client to the domain root, discarding any path or query string
+       * present in the originally-requested URL.
+       *
+       * Note: This script was designed to work around the issue of GitHub Pages
+       *       showing an HTTP 404 error page when the user visits a non-root path
+       *       via a means other than client-side routing; for example, when the
+       *       user reloads the web page when viewing a non-root page of the site.
+       *
+       * Note: This script only works when the site is deployed at the _root_ of a
+       *       domain (e.g. "https://site.example.com") as opposed to a deeper
+       *       location (e.g. "https://site.example.com/path/to/site). The latter
+       *       situation can be handled by something more sophisticated, such as:
+       *       https://github.com/rafgraph/spa-github-pages/tree/gh-pages
+       *
+       * References:
+       * - https://developer.mozilla.org/en-US/docs/Web/API/Location#instance_properties
+       * - https://developer.mozilla.org/en-US/docs/Web/API/Location/replace
+       * - https://developer.mozilla.org/en-US/docs/Web/API/URL
+       */
+      (function navigateToRoot() {
+        // Extract parts of the originally-requested URL.
+        const { protocol, host } = window.location;
+
+        // Build the new URL to which we will navigate the client.
+        const newUrl = new URL(`${protocol}//${host}`);
+
+        // Navigate the client to the new URL in a way that does not
+        // push the originally-requested URL onto the history stack.
+        window.location.assign(newUrl);
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Currently, when a client navigates to a non-root URL of the web app via a means other than client-side routing (e.g. via reloading the web page or via typing the URL into the address bar); GitHub Pages displays an HTTP 404 Error Page. This phenomenon is described in #20.

GitHub Pages supports the use of custom `404.html` pages, which is what I am introducing with this branch. This custom `404.html` page does one thing: it redirects the client to the root URL of the site, discarding any path or query string they might have originally requested. I consider this to be an improvement over the current behavior.

> Note: The reason I didn't use the hard-coded relative URL of `/` to refer to the root URL of the site; is that I wanted to lay a foundation for moving to a more sophisticated solution, such as the one referenced below.

Should we—in the future—decide to allow users to enter the app at non-root paths (i.e. to open the app directly to a "deep" screen), we can switch to a solution like the one described at https://github.com/rafgraph/spa-github-pages/.