### PR TITLE
Replace boilerplate app name with real one

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Ionic App</title>
+    <title>NMDC Field Notes</title>
 
     <base href="/" />
 
@@ -20,7 +20,7 @@
 
     <!-- add to homescreen for ios -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-title" content="Ionic App" />
+    <meta name="apple-mobile-web-app-title" content="NMDC Field Notes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
   </head>
   <body>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "Ionic App",
-  "name": "My Ionic App",
+  "short_name": "Field Notes",
+  "name": "NMDC Field Notes",
   "icons": [
     {
       "src": "assets/icon/favicon.png",


### PR DESCRIPTION
### Summary of changes

- I updated the `index.html` and `public/manifest.json` files to say "NMDC Field Notes" (or "Field Notes") instead of "Ionic App"