### PR TITLE
Support deep linking on GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,41 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      /**
+       * Retrieves the originally-requested URL, if any, from `sessionStorage` and navigates to it on the client side.
+       *
+       * Details: If `sessionStorage` contains an originally-requested URL that both (a) has the same origin as the
+       * current URL; and (b) differs from the current URL; remove that item from `sessionStorage` and
+       * do "client-side navigation" to that originally-requested URL.
+       *
+       * References:
+       * - https://www.smashingmagazine.com/2016/08/sghpa-single-page-app-hack-github-pages/ (RE: the overall technique)
+       * - https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#definition_of_an_origin
+       * - https://developer.mozilla.org/en-US/docs/Web/API/Location#instance_properties
+       * - https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage
+       * - `404.html`
+       */
+      (function checkForOriginallyRequestedURL(
+        sessionStorage,
+        location,
+        history,
+      ) {
+        const SESSION_STORAGE_KEY = "_originallyRequestedURLStr";
+        const originallyRequestedURLStr =
+          sessionStorage.getItem(SESSION_STORAGE_KEY);
+        if (originallyRequestedURLStr !== null) {
+          const originallyRequestedURL = new URL(originallyRequestedURLStr);
+          if (
+            originallyRequestedURL.origin === location.origin &&
+            originallyRequestedURL.href !== location.href
+          ) {
+            sessionStorage.removeItem(SESSION_STORAGE_KEY); // we do this as late as possible to help with debugging
+            history.replaceState(null, null, originallyRequestedURL);
+          }
+        }
+      })(window.sessionStorage, window.location, window.history);
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -27,11 +27,12 @@
     <div id="root"></div>
     <script>
       /**
-       * Retrieves the originally-requested URL, if any, from `sessionStorage` and navigates to it on the client side.
+       * Retrieves the originally-requested URL, if any, from `sessionStorage` and—if it is "valid and useful"—deletes
+       * that `sessionStorage` item and navigates to that URL (i.e. path) on the client side.
        *
-       * Note: If `sessionStorage` contains an originally-requested URL that both (a) has the same origin as the
-       *       current URL; and (b) differs from the current URL; this function removes that `sessionStorage` item
-       *       and performs "client-side navigation" to that originally-requested URL.
+       * Note: In the context of this function, an originally-requested URL...
+       *       - is "valid" if it has the same origin as the current URL
+       *       - is "useful" if it differs from the current URL
        *
        * Note: We do this before the React app runs. The React app will only be aware of the "final" URL.
        *

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
        * References:
        * - https://www.smashingmagazine.com/2016/08/sghpa-single-page-app-hack-github-pages/ (RE: the overall technique)
        * - https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#definition_of_an_origin
-       * - `404.html`
+       * - `404.html` (contains the script that stores the originally-requested URL in `sessionStorage`)
        */
       (function navigateToOriginallyRequestedURL(
         sessionStorage,

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
        * - https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#definition_of_an_origin
        * - `404.html`
        */
-      (function checkForOriginallyRequestedURL(
+      (function navigateToOriginallyRequestedURL(
         sessionStorage,
         location,
         history,

--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@
     <div id="root"></div>
     <script>
       /**
-       * Retrieves the originally-requested URL, if any, from `sessionStorage` and—if it is "valid and useful"—deletes
-       * that `sessionStorage` item and navigates to that URL (i.e. path) on the client side.
+       * Retrieves the originally-requested URL, if any, from `sessionStorage` and—if that URL is both "valid and
+       * useful"—deletes that `sessionStorage` item and navigates to that URL on the client side.
        *
        * Note: In the context of this function, an originally-requested URL...
        *       - is "valid" if it has the same origin as the current URL
@@ -55,7 +55,7 @@
             originallyRequestedURL.origin === location.origin &&
             originallyRequestedURL.href !== location.href
           ) {
-            sessionStorage.removeItem(SESSION_STORAGE_KEY); // we do this as late as possible to help with debugging
+            sessionStorage.removeItem(SESSION_STORAGE_KEY); // we do this as late as possible to facilitate debugging
             history.replaceState(null, null, originallyRequestedURL);
           }
         }

--- a/index.html
+++ b/index.html
@@ -29,15 +29,15 @@
       /**
        * Retrieves the originally-requested URL, if any, from `sessionStorage` and navigates to it on the client side.
        *
-       * Details: If `sessionStorage` contains an originally-requested URL that both (a) has the same origin as the
-       * current URL; and (b) differs from the current URL; remove that item from `sessionStorage` and
-       * do "client-side navigation" to that originally-requested URL.
+       * Note: If `sessionStorage` contains an originally-requested URL that both (a) has the same origin as the
+       *       current URL; and (b) differs from the current URL; this function removes that `sessionStorage` item
+       *       and performs "client-side navigation" to that originally-requested URL.
+       *
+       * Note: We do this before the React app runs. The React app will only be aware of the "final" URL.
        *
        * References:
        * - https://www.smashingmagazine.com/2016/08/sghpa-single-page-app-hack-github-pages/ (RE: the overall technique)
        * - https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#definition_of_an_origin
-       * - https://developer.mozilla.org/en-US/docs/Web/API/Location#instance_properties
-       * - https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage
        * - `404.html`
        */
       (function checkForOriginallyRequestedURL(

--- a/public/404.html
+++ b/public/404.html
@@ -14,7 +14,7 @@
        *
        * References:
        * - https://www.smashingmagazine.com/2016/08/sghpa-single-page-app-hack-github-pages/ (RE: the overall technique)
-       * - `index.html`
+       * - `index.html` (contains the script that reads the originally-requested URL from `sessionStorage`)
        */
       (function storeOriginallyRequestedURL(sessionStorage, location) {
         const originallyRequestedURLStr = location.href;

--- a/public/404.html
+++ b/public/404.html
@@ -14,8 +14,6 @@
        *
        * References:
        * - https://www.smashingmagazine.com/2016/08/sghpa-single-page-app-hack-github-pages/ (RE: the overall technique)
-       * - https://developer.mozilla.org/en-US/docs/Web/API/Location#instance_properties
-       * - https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage
        * - `index.html`
        */
       (function storeOriginallyRequestedURL(sessionStorage, location) {

--- a/public/404.html
+++ b/public/404.html
@@ -3,40 +3,30 @@
   <head>
     <meta charset="utf-8" />
     <title>NMDC Field Notes</title>
-  </head>
-  <body>
     <script>
       /**
-       * Navigate the client to the domain root, discarding any path or query string
-       * present in the originally-requested URL.
+       * Stores the originally-requested URL in `sessionStorage` so it can be retrieved from a different web page.
        *
-       * Note: This script was designed to work around the issue of GitHub Pages
-       *       showing an HTTP 404 error page when the user visits a non-root path
-       *       via a means other than client-side routing; for example, when the
-       *       user reloads the web page when viewing a non-root page of the site.
-       *
-       * Note: This script only works when the site is deployed at the _root_ of a
-       *       domain (e.g. "https://site.example.com") as opposed to a deeper
-       *       location (e.g. "https://site.example.com/path/to/site). The latter
-       *       situation can be handled by something more sophisticated, such as:
-       *       https://github.com/rafgraph/spa-github-pages/tree/gh-pages
+       * Note: This script—together with the "refresh" meta tag that follows it—were designed to work around the issue
+       *       of GitHub Pages showing an HTTP 404 error page when the user visits a non-root path via a means other
+       *       than client-side routing; for example, when the user is redirected to a non-root path after logging in
+       *       via ORCiD, or when the user reloads the web page after having client-side-navigated to a non-root path.
        *
        * References:
+       * - https://www.smashingmagazine.com/2016/08/sghpa-single-page-app-hack-github-pages/ (RE: the overall technique)
        * - https://developer.mozilla.org/en-US/docs/Web/API/Location#instance_properties
-       * - https://developer.mozilla.org/en-US/docs/Web/API/Location/replace
-       * - https://developer.mozilla.org/en-US/docs/Web/API/URL
+       * - https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage
+       * - `index.html`
        */
-      (function navigateToRoot() {
-        // Extract parts of the originally-requested URL.
-        const { protocol, host } = window.location;
-
-        // Build the new URL to which we will navigate the client.
-        const newUrl = new URL(`${protocol}//${host}`);
-
-        // Navigate the client to the new URL in a way that does not
-        // push the originally-requested URL onto the history stack.
-        window.location.assign(newUrl);
-      })();
+      (function storeOriginallyRequestedURL(sessionStorage, location) {
+        const originallyRequestedURLStr = location.href;
+        const SESSION_STORAGE_KEY = "_originallyRequestedURLStr";
+        sessionStorage.setItem(SESSION_STORAGE_KEY, originallyRequestedURLStr);
+      })(window.sessionStorage, window.location);
     </script>
-  </body>
+    <!-- Tell the web browser to navigate to the specified path immediately (i.e. in 0 seconds). -->
+    <!-- Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#http-equiv -->
+    <meta http-equiv="refresh" content="0;url='/'" />
+  </head>
+  <body></body>
 </html>

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -47,7 +47,7 @@ const Router: React.FC = () => {
         <Route exact path={PATHS.ROOT}>
           <Redirect to={apiToken ? PATHS.HOME_PAGE : PATHS.WELCOME_PAGE} />
         </Route>
-        {/* Fallback route for when the requested path doesn't match any of the above ones. */}
+        {/* Fallback route for when the requested path doesn't match any of the above paths. */}
         <Redirect to={PATHS.ROOT} />
       </IonRouterOutlet>
     </IonReactRouter>

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -47,6 +47,8 @@ const Router: React.FC = () => {
         <Route exact path={PATHS.ROOT}>
           <Redirect to={apiToken ? PATHS.HOME_PAGE : PATHS.WELCOME_PAGE} />
         </Route>
+        {/* Fallback route for when the requested path doesn't match any of the above ones. */}
+        <Redirect to={PATHS.ROOT} />
       </IonRouterOutlet>
     </IonReactRouter>
   );


### PR DESCRIPTION
### Summary of changes

- Implemented https://www.smashingmagazine.com/2016/08/sghpa-single-page-app-hack-github-pages/ (and added a check that the originally-requested URL and the site URL have the same origin; which is something `history.replaceState()` requires, but is not addressed in the article)
- Added a fallback route so that, when someone visits a path that doesn't exist in the app (such as `/foo`), the app redirects them to the root path