### PR TITLE
Implement tab-based navigation

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -12,17 +12,22 @@ import { useStore } from "./Store";
 import LogoutPage from "./pages/LogoutPage/LogoutPage";
 import StudyViewPage from "./pages/StudyViewPage/StudyViewPage";
 import StudyCreatePage from "./pages/StudyCreatePage/StudyCreatePage";
+import TabNavigator from "./components/TabNavigator/TabNavigator";
+import PlaceholderPage from "./pages/PlaceholderPage";
 
 export const PATHS = {
   ROOT: "/",
-  HOME_PAGE: "/home",
+  HOME_PAGE: "/in/home",
   TUTORIAL_PAGE: "/tutorial",
   WELCOME_PAGE: "/welcome",
   LOGIN_PAGE: "/login",
   TOKEN_PAGE: "/token",
   LOGOUT_PAGE: "/logout",
-  STUDY_CREATE_PAGE: "/study/create",
-  STUDY_VIEW_PAGE: "/study/:id",
+  STUDY_CREATE_PAGE: "/in/study/create",
+  STUDY_VIEW_PAGE: "/in/study/:id",
+  TABBED_AREA: "/in",
+  GUIDE_PAGE: "/in/guide",
+  SETTINGS_PAGE: "/in/settings",
 };
 
 const Router: React.FC = () => {
@@ -45,16 +50,36 @@ const Router: React.FC = () => {
         <Route exact path={PATHS.TUTORIAL_PAGE}>
           <TutorialPage />
         </Route>
-        <AuthRoute path={PATHS.STUDY_VIEW_PAGE}>
-          <StudyViewPage />
-        </AuthRoute>
-        {/* Not sure why this needs to come after the view route, but it only works that way */}
-        <AuthRoute exact path={PATHS.STUDY_CREATE_PAGE}>
-          <StudyCreatePage />
-        </AuthRoute>
-        <AuthRoute exact path={PATHS.HOME_PAGE}>
-          <HomePage />
-        </AuthRoute>
+
+        <Route path={PATHS.TABBED_AREA}>
+          <TabNavigator>
+            <AuthRoute path={PATHS.STUDY_VIEW_PAGE}>
+              <StudyViewPage />
+            </AuthRoute>
+            {/* Not sure why this needs to come after the view route, but it only works that way */}
+            <AuthRoute exact path={PATHS.STUDY_CREATE_PAGE}>
+              <StudyCreatePage />
+            </AuthRoute>
+            <AuthRoute exact path={PATHS.HOME_PAGE}>
+              <HomePage />
+            </AuthRoute>
+            <AuthRoute exact path={PATHS.GUIDE_PAGE}>
+              <PlaceholderPage
+                title={"Guide"}
+                body={"Base route on Guide tab"}
+              />
+            </AuthRoute>
+            <AuthRoute exact path={PATHS.SETTINGS_PAGE}>
+              <PlaceholderPage
+                title={"Settings"}
+                body={"Base route on Settings tab"}
+              />
+            </AuthRoute>
+            {/* Fallback route for when the requested path doesn't match any of the above paths. */}
+            <Redirect to={PATHS.HOME_PAGE} />
+          </TabNavigator>
+        </Route>
+
         <Route exact path={PATHS.ROOT}>
           <Redirect to={apiToken ? PATHS.HOME_PAGE : PATHS.WELCOME_PAGE} />
         </Route>

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -53,12 +53,11 @@ const Router: React.FC = () => {
 
         <Route path={PATHS.TABBED_AREA}>
           <TabNavigator>
-            <AuthRoute path={PATHS.STUDY_VIEW_PAGE}>
-              <StudyViewPage />
-            </AuthRoute>
-            {/* Not sure why this needs to come after the view route, but it only works that way */}
             <AuthRoute exact path={PATHS.STUDY_CREATE_PAGE}>
               <StudyCreatePage />
+            </AuthRoute>
+            <AuthRoute path={PATHS.STUDY_VIEW_PAGE}>
+              <StudyViewPage />
             </AuthRoute>
             <AuthRoute exact path={PATHS.HOME_PAGE}>
               <HomePage />

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -17,7 +17,7 @@ import PlaceholderPage from "./pages/PlaceholderPage";
 
 export const PATHS = {
   ROOT: "/",
-  HOME_PAGE: "/in/home",
+  HOME_PAGE: "/in/study",
   TUTORIAL_PAGE: "/tutorial",
   WELCOME_PAGE: "/welcome",
   LOGIN_PAGE: "/login",

--- a/src/components/StudyList/StudyList.tsx
+++ b/src/components/StudyList/StudyList.tsx
@@ -12,6 +12,7 @@ import {
 } from "@ionic/react";
 import { SubmissionMetadata } from "../../api";
 import Pluralize from "../Pluralize/Pluralize";
+import { PATHS } from "../../Router";
 
 const getSubmissionSamples = (submission: SubmissionMetadata) => {
   const environmentalPackageName =
@@ -36,7 +37,7 @@ const StudyList: React.FC = () => {
     <>
       <IonListHeader>
         <IonLabel>Studies</IonLabel>
-        <IonButton routerLink={`/study/create`}>New</IonButton>
+        <IonButton routerLink={PATHS.STUDY_CREATE_PAGE}>New</IonButton>
       </IonListHeader>
 
       <IonProgressBar
@@ -59,7 +60,7 @@ const StudyList: React.FC = () => {
             {concatenatedSubmissions.map((submission) => (
               <IonItem
                 key={submission.id}
-                routerLink={`/study/${submission.id}`}
+                routerLink={PATHS.STUDY_VIEW_PAGE.replace(":id", submission.id)}
               >
                 <IonLabel>
                   <h3>

--- a/src/components/TabNavigator/TabNavigator.tsx
+++ b/src/components/TabNavigator/TabNavigator.tsx
@@ -1,0 +1,48 @@
+import React, { PropsWithChildren } from "react";
+import {
+  IonIcon,
+  IonLabel,
+  IonRouterOutlet,
+  IonTabBar,
+  IonTabButton,
+  IonTabs,
+} from "@ionic/react";
+import {
+  create as studiesIcon,
+  map as guideIcon,
+  settings as settingsIcon,
+} from "ionicons/icons";
+import { PATHS } from "../../Router";
+
+interface Props extends PropsWithChildren {}
+
+const TabNavigator: React.FC<Props> = ({ children }) => {
+  // Note: As shown in the Ionic docs, this `IonTabs` element wraps two things:
+  //       (a) an `IonTabBar` element, which will appear as a horizontal navbar at the bottom of the viewport; and
+  //       (b) an `IonRouterOutlet` element containing the passed-in routes to components, each of which will share the
+  //           viewport with the aforementioned navbar.
+  //       Reference: https://ionicframework.com/docs/react/navigation#working-with-tabs
+  return (
+    <IonTabs>
+      <IonRouterOutlet>{children}</IonRouterOutlet>
+
+      {/* Tab navigation bar at the bottom of the viewport. */}
+      <IonTabBar slot={"bottom"}>
+        <IonTabButton tab={"studies"} href={PATHS.HOME_PAGE}>
+          <IonIcon icon={studiesIcon} />
+          <IonLabel>Studies</IonLabel>
+        </IonTabButton>
+        <IonTabButton tab={"guide"} href={PATHS.GUIDE_PAGE}>
+          <IonIcon icon={guideIcon} />
+          <IonLabel>Guide</IonLabel>
+        </IonTabButton>
+        <IonTabButton tab={"settings"} href={PATHS.SETTINGS_PAGE}>
+          <IonIcon icon={settingsIcon} />
+          <IonLabel>Settings</IonLabel>
+        </IonTabButton>
+      </IonTabBar>
+    </IonTabs>
+  );
+};
+
+export default TabNavigator;

--- a/src/pages/PlaceholderPage.tsx
+++ b/src/pages/PlaceholderPage.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import {
+  IonContent,
+  IonHeader,
+  IonPage,
+  IonTitle,
+  IonToolbar,
+} from "@ionic/react";
+
+interface Props {
+  title?: string;
+  body?: string;
+}
+
+/**
+ * This is a basic page we can use for demonstration purposes during development.
+ *
+ * TODO: Delete this placeholder component once we think we won't use it anymore.
+ */
+const PlaceholderPage: React.FC<Props> = ({ title, body }) => {
+  return (
+    <IonPage>
+      <IonHeader translucent={true}>
+        <IonToolbar>
+          <IonTitle>{title}</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent fullscreen className={"ion-padding"}>
+        {body}
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default PlaceholderPage;


### PR DESCRIPTION
In this branch, I implemented tab-based navigation.

![image](https://github.com/microbiomedata/nmdc-field-notes/assets/134325062/8e02d61d-22e5-4650-9111-b5b5262eb2c1)

There are 3 tabs: 
- Studies
- Guide
- Settings

The `TabNavigator` component renders a horizontal bar containing those tabs; and also renders a router outlet for all routes that are "within" the tabbed section of the app. All such routes share a common route prefix (I arbitrarily set it to `/in`), which is matched by an application-level route that renders the `TabNavigator`, itself.

I also introduced `PlaceholderPage`, a temporary component we can use when we want an `IonPage` containing some basic content, in order to demonstrate functionality (e.g. a target to route to).

I also updated some relatively hard-coded paths I came across so that they use the common `PATHS` object instead. On a side note, I saw that there is a [draft PR](https://github.com/microbiomedata/nmdc-field-notes/pull/37/files#diff-9ff5b9d254197d871a6540cee2f27c8deb4e62c75b869e2cbf2fd265870ef9b7R20) in which the `PATHS` object will be replaced with something else—that's OK with me.

Finally, I swapped a couple routes back to an order that I, and I think one of my teammates, finds more intuitive (the previous order was the way it was because it was working, while the order we found more intuitive was not). It seems to me that the introduction of the tab navigation has changed how those two routes "behave" 🤷 :
```tsx
            <AuthRoute exact path={PATHS.STUDY_CREATE_PAGE}>
              <StudyCreatePage />
            </AuthRoute>
            <AuthRoute path={PATHS.STUDY_VIEW_PAGE}>
              <StudyViewPage />
            </AuthRoute>
```