### PR TITLE
Create universal link-related files in `public` folder

### DIFF
--- a/public/.well-known/README.md
+++ b/public/.well-known/README.md
@@ -9,6 +9,7 @@ be included in the build (and, as a result, deployed to the web server) verbatim
 > like [this one](https://github.com/vitejs/vite/discussions/7374#discussioncomment-8557938) to delete it from the
 > build; but use a Node.js script instead of `rm` to delete the file,
 > since we know `node` will be present on the system (I think Windows offers `del` instead of `rm`).
+>
 > ```shell
 > node -e "const fs = require('fs'); fs.unlinkSync('path/to/file');"
 > ```

--- a/public/.well-known/README.md
+++ b/public/.well-known/README.md
@@ -23,9 +23,9 @@ taps on a link that begins with `https://fieldnotes.microbiomedata.org`;
 the operating system on their device (i.e. iOS) will first check for the presence of this file on this web server.
 This file essentially tells iOS that this web server trusts the mobile app to handle the link.
 
-## `assetlinks.json` (coming soon)
+## `assetlinks.json`
 
-This file—once we create it—will be used for
+This file is used for
 [Android universal links](https://capacitorjs.com/docs/guides/deep-links#create-site-association-file-1).
 
-Coming soon...
+It was generated using https://developers.google.com/digital-asset-links/tools/generator.

--- a/public/.well-known/README.md
+++ b/public/.well-known/README.md
@@ -1,0 +1,31 @@
+# `.well-known/`
+
+This folder contains files that mobile devices on the Internet are programmed to check for at a specific path.
+
+Since this folder is within the `public` folder, its contents—even this `README.md` file—will
+be included in the build (and, as a result, deployed to the web server) verbatim.
+
+> **Note:** To prevent this `README.md` file from being deployed, we may be able to employ a solution
+> like [this one](https://github.com/vitejs/vite/discussions/7374#discussioncomment-8557938) to delete it from the
+> build; but use a Node.js script instead of `rm` to delete the file,
+> since we know `node` will be present on the system (I think Windows offers `del` instead of `rm`).
+> ```shell
+> node -e "const fs = require('fs'); fs.unlinkSync('path/to/file');"
+> ```
+
+## `apple-app-site-association`
+
+This file is used for
+[Apple/iOS universal links](https://capacitorjs.com/docs/guides/deep-links#create-site-association-file).
+
+When someone using an iOS device that has the NMDC Field Notes mobile app installed on it,
+taps on a link that begins with `https://fieldnotes.microbiomedata.org`;
+the operating system on their device (i.e. iOS) will first check for the presence of this file on this web server.
+This file essentially tells iOS that this web server trusts the mobile app to handle the link.
+
+## `assetlinks.json` (coming soon)
+
+This file—once we create it—will be used for
+[Android universal links](https://capacitorjs.com/docs/guides/deep-links#create-site-association-file-1).
+
+Coming soon...

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,11 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "4L4Y2A43SA.org.microbiomedata.fieldnotes",
+        "paths": ["*"]
+      }
+    ]
+  }
+}

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,8 +1,6 @@
 [
   {
-    "relation": [
-      "delegate_permission/common.handle_all_urls"
-    ],
+    "relation": ["delegate_permission/common.handle_all_urls"],
     "target": {
       "namespace": "android_app",
       "package_name": "org.microbiomedata.fieldnotes",

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "org.microbiomedata.fieldnotes",
+      "sha256_cert_fingerprints": [
+        "61:52:55:19:5C:6E:AF:E2:C4:20:49:37:9F:F6:01:74:7E:00:E6:51:E4:96:F4:0A:DE:1B:09:65:A8:D3:0F:B3"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
In this branch, I created two files:
- `apple-app-site-association`
- `assetlinks.json`

The first one will be used for Apple (iOS) universal links.

The second one will be used for Android universal links.

Both files are in `public/.well-known/`, so they will be included as-is in the build that gets deployed to GitHub Pages.

I also created a `README.md` file in the same directory. That file contains documentation about the directory and its contents.

---

While these changes tackle part of https://github.com/microbiomedata/nmdc-field-notes/issues/28, they do not tackle the entire ticket. Therefore, if GitHub automatically closes that ticket when this gets merged in, I will reopen the ticket.