### PR TITLE
Configure Android app to recognize incoming links

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,6 +22,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
+            <!-- This element makes it so the Android app will recognize incoming links. -->
+            <!-- Reference: https://capacitorjs.com/docs/guides/deep-links#add-intent-filter -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="fieldnotes.microbiomedata.org" />
+            </intent-filter>
+
         </activity>
 
         <provider


### PR DESCRIPTION
In this branch, I updated the `AndroidManifest.xml` file—as instructed in the [Ionic docs](https://capacitorjs.com/docs/guides/deep-links#add-intent-filter) about universal links—so that the Android app would recognize incoming links.