### PR TITLE
Decouple application code from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ npm install
 
 ### Setup local environment
 
-The application loads values from environment variables defined in a `.env.local` file. This file is not checked into source control. It is [loaded automatically by Vite](https://vitejs.dev/guide/env-and-mode), and the values are exposed on the `import.meta.env` object. You can copy the `.env.local.example` file to `.env.local` to get started.
+The application loads values from environment variables defined in a `.env.local` file.
+
+> That file is intentionally not stored in the Git repository. That file is [loaded automatically by Vite](https://vitejs.dev/guide/env-and-mode), which exposes the environment variables via the `import.meta.env` object. The application's `config.ts` file then uses that object to make a `config` object—and the rest of the application uses that `config` object instead of directly accessing the `import.meta.env` object.
+
+You can copy the `.env.local.example` file to `.env.local` to get started.
 
 ```shell
 cp .env.local.example .env.local

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,3 +1,5 @@
+import config from './config';
+
 export interface Paginated<Type> {
   count: number;
   readonly results: Type[];
@@ -94,7 +96,7 @@ class FetchClient {
 
 class NmdcServerClient extends FetchClient {
   constructor() {
-    super(import.meta.env.VITE_NMDC_SERVER_API_URL, {
+    super(config.NMDC_SERVER_API_URL, {
       headers: {
         "Content-Type": "application/json",
       },

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import config from './config';
+import config from "./config";
 
 export interface Paginated<Type> {
   count: number;

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,7 +29,8 @@ const config: Config = {
    * Default: The `/login` endpoint in the dev environment.
    */
   NMDC_SERVER_LOGIN_URL:
-    env.VITE_NMDC_SERVER_LOGIN_URL || "https://data-dev.microbiomedata.org/login",
+    env.VITE_NMDC_SERVER_LOGIN_URL ||
+    "https://data-dev.microbiomedata.org/login",
 };
 
 export default config;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,35 @@
+/**
+ * Configure the app based upon environment variables.
+ *
+ * This module acts as the single interface between the `import.meta.env` object and the application code.
+ * This module adds (a) type hints, (b) documentation, (c) default values, and (d) sanitization.
+ *
+ * Reference: https://vitejs.dev/guide/env-and-mode
+ */
+
+const env = import.meta.env;
+
+interface Config {
+  NMDC_SERVER_API_URL: string;
+  NMDC_SERVER_LOGIN_URL: string;
+}
+
+const config: Config = {
+  /**
+   * URL of the endpoint the mobile app can use to access the NMDC data portal API.
+   *
+   * Default: The `/api` endpoint in the dev environment.
+   */
+  NMDC_SERVER_API_URL:
+    env.VITE_NMDC_SERVER_API_URL || "https://data-dev.microbiomedata.org/api",
+
+  /**
+   * URL of the endpoint the mobile app can use to authenticate with the NMDC data portal API.
+   *
+   * Default: The `/login` endpoint in the dev environment.
+   */
+  NMDC_SERVER_LOGIN_URL:
+    env.VITE_NMDC_SERVER_LOGIN_URL || "https://data-dev.microbiomedata.org/login",
+};
+
+export default config;

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -2,29 +2,30 @@ import { delay, http, HttpResponse } from "msw";
 import { Paginated, SubmissionMetadata } from "../api";
 import { submissions } from "./fixtures";
 import { setupServer } from "msw/node";
+import config from '../config';
 
-const { VITE_NMDC_SERVER_API_URL } = import.meta.env;
+const { NMDC_SERVER_API_URL } = config;
 
 export const handlers = [
   http.get<
     Record<string, never>,
     Record<string, never>,
     Paginated<SubmissionMetadata>
-  >(`${VITE_NMDC_SERVER_API_URL}/metadata_submission`, async () => {
+  >(`${NMDC_SERVER_API_URL}/metadata_submission`, async () => {
     return HttpResponse.json({
       count: submissions.length,
       results: submissions,
     });
   }),
   http.get<{ id: string }, Record<string, never>, SubmissionMetadata>(
-    `${VITE_NMDC_SERVER_API_URL}/metadata_submission/:id`,
+    `${NMDC_SERVER_API_URL}/metadata_submission/:id`,
     async ({ params }) => {
       const { id } = params;
       return HttpResponse.json(submissions.find((s) => s.id === id));
     },
   ),
   http.patch<{ id: string }, SubmissionMetadata, SubmissionMetadata>(
-    `${VITE_NMDC_SERVER_API_URL}/metadata_submission/:id`,
+    `${NMDC_SERVER_API_URL}/metadata_submission/:id`,
     async ({ params, request }) => {
       const { id } = params;
       const body = await request.json();
@@ -34,13 +35,13 @@ export const handlers = [
       });
     },
   ),
-  http.get(`${VITE_NMDC_SERVER_API_URL}/me`, async () => {
+  http.get(`${NMDC_SERVER_API_URL}/me`, async () => {
     return HttpResponse.json("Test Testerson");
   }),
 ];
 
 export const patchMetadataSubmissionError = http.patch<{ id: string }>(
-  `${VITE_NMDC_SERVER_API_URL}/metadata_submission/:id`,
+  `${NMDC_SERVER_API_URL}/metadata_submission/:id`,
   async () => {
     // This delay helps tests validate optimistic updates before the request fails
     await delay(300);

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -2,7 +2,7 @@ import { delay, http, HttpResponse } from "msw";
 import { Paginated, SubmissionMetadata } from "../api";
 import { submissions } from "./fixtures";
 import { setupServer } from "msw/node";
-import config from '../config';
+import config from "../config";
 
 const { NMDC_SERVER_API_URL } = config;
 

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { IonButton, IonPage } from "@ionic/react";
-
+import config from "../../config";
 import { Browser } from "@capacitor/browser";
 
 const LoginPage: React.FC = () => {
   const handleLogin = async () => {
     await Browser.open({
-      url: `${import.meta.env.VITE_NMDC_SERVER_LOGIN_URL}?behavior=app`,
+      url: `${config.NMDC_SERVER_LOGIN_URL}?behavior=app`,
       windowName: "_self", // web only
     });
   };

--- a/src/pages/WelcomePage/WelcomePage.tsx
+++ b/src/pages/WelcomePage/WelcomePage.tsx
@@ -18,11 +18,12 @@ import Logo from "../../components/Logo/Logo";
 import { paths } from "../../Router";
 import "./WelcomePage.css";
 import { Browser } from "@capacitor/browser";
+import config from "../../config";
 
 const WelcomePage: React.FC = () => {
   const handleLogin = async () => {
     await Browser.open({
-      url: `${import.meta.env.VITE_NMDC_SERVER_LOGIN_URL}?behavior=app`,
+      url: `${config.NMDC_SERVER_LOGIN_URL}?behavior=app`,
       windowName: "_self", // web only
     });
   };


### PR DESCRIPTION
In this branch, I introduced a layer of abstraction between the `import.meta.env` object and the rest of the application code. The new layer provides type information, documentation, and default values. It could also provide validation/sanitization/transformation in the future. I think the introduction of this new layer will make it easier for people to work on application code, as IDEs can now validate the (names and types of) ~environment variables~ "config variables" referenced by the application code.

Here's a pair of diagrams showing the "before" and "after" architecture (except that I accidentally depicted the new `config.ts` file as being outside of the application code, whereas it is part of the application code in reality).

![image](https://github.com/microbiomedata/nmdc-field-notes/assets/134325062/e2d7cbb9-fcdc-4e39-b53d-1e4c09702d36)
