### PR TITLE
Implement study edit and create screens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "minisearch": "^6.3.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hook-form": "^7.51.0",
         "react-minisearch": "^6.3.0",
         "react-router": "^5.3.4",
         "react-router-dom": "^5.3.4"
@@ -15456,6 +15457,21 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
       "dev": true
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.51.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.51.0.tgz",
+      "integrity": "sha512-BggOy5j58RdhdMzzRUHGOYhSz1oeylFAv6jUSG86OvCIvlAvS7KvnRY7yoAf2pfEiPN7BesnR0xx73nEk3qIiw==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "minisearch": "^6.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.51.0",
     "react-minisearch": "^6.3.0",
     "react-router": "^5.3.4",
     "react-router-dom": "^5.3.4"

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -1,4 +1,5 @@
 import { nmdcServerClient } from "./api";
+import { defaultSubmission } from "./data";
 
 test("getSubmissionList", async () => {
   const submissions = await nmdcServerClient.getSubmissionList();
@@ -25,14 +26,10 @@ test("updateSubmission", async () => {
 });
 
 test("createSubmission", async () => {
-  const submission = await nmdcServerClient.createSubmission({
-    metadata_submission: {
-      studyForm: {
-        studyName: "New Study",
-        piEmail: "test@fake.edu",
-      },
-    },
-  });
+  const submissionCreate = defaultSubmission();
+  submissionCreate.metadata_submission.studyForm.studyName = "New Study";
+  submissionCreate.metadata_submission.studyForm.piEmail = "test@fake.edu";
+  const submission = await nmdcServerClient.createSubmission(submissionCreate);
   expect(submission.metadata_submission.studyForm.studyName).toEqual(
     "New Study",
   );

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -24,6 +24,29 @@ test("updateSubmission", async () => {
   );
 });
 
+test("createSubmission", async () => {
+  const submission = await nmdcServerClient.createSubmission({
+    metadata_submission: {
+      studyForm: {
+        studyName: "New Study",
+        piEmail: "test@fake.edu",
+      },
+    },
+  });
+  expect(submission.metadata_submission.studyForm.studyName).toEqual(
+    "New Study",
+  );
+  expect(submission.metadata_submission.studyForm.piEmail).toEqual(
+    "test@fake.edu",
+  );
+});
+
+test("deleteSubmission", async () => {
+  const submissionId = "00000000-0000-0000-0000-000000000001";
+  await nmdcServerClient.deleteSubmission(submissionId);
+  // Nothing to explicitly test here, just that it doesn't throw an error
+});
+
 test("getCurrentUser", async () => {
   const user = await nmdcServerClient.getCurrentUser();
   expect(user).toEqual("Test Testerson");

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -1,5 +1,5 @@
 import { nmdcServerClient } from "./api";
-import { defaultSubmission } from "./data";
+import { initSubmission } from "./data";
 
 test("getSubmissionList", async () => {
   const submissions = await nmdcServerClient.getSubmissionList();
@@ -26,7 +26,7 @@ test("updateSubmission", async () => {
 });
 
 test("createSubmission", async () => {
-  const submissionCreate = defaultSubmission();
+  const submissionCreate = initSubmission();
   submissionCreate.metadata_submission.studyForm.studyName = "New Study";
   submissionCreate.metadata_submission.studyForm.piEmail = "test@fake.edu";
   const submission = await nmdcServerClient.createSubmission(submissionCreate);

--- a/src/api.ts
+++ b/src/api.ts
@@ -164,8 +164,6 @@ class NmdcServerClient extends FetchClient {
   }
 
   async deleteSubmission(id: string) {
-    // Use fetch instead of JSON because this sends and empty response
-    // with a 204 status on success. 
     return this.fetch(`/metadata_submission/${id}`, {
       method: "DELETE",
     });

--- a/src/api.ts
+++ b/src/api.ts
@@ -201,7 +201,7 @@ class FetchClient {
     return response;
   }
 
-  protected async json<T>(
+  protected async fetchJson<T>(
     endpoint: string,
     options: RequestInit = {},
   ): Promise<T> {
@@ -243,7 +243,7 @@ class NmdcServerClient extends FetchClient {
       ...pagination,
     };
     const query = new URLSearchParams(pagination as Record<string, string>);
-    const submissions = await this.json<Paginated<SubmissionMetadata>>(
+    const submissions = await this.fetchJson<Paginated<SubmissionMetadata>>(
       `/metadata_submission?${query}`,
     );
     submissions.results.forEach((submission) => {
@@ -253,7 +253,7 @@ class NmdcServerClient extends FetchClient {
   }
 
   async getSubmission(id: string) {
-    const submission = await this.json<SubmissionMetadata>(
+    const submission = await this.fetchJson<SubmissionMetadata>(
       `/metadata_submission/${id}`,
     );
     NmdcServerClient.injectStableSampleIndexes(submission);
@@ -261,14 +261,14 @@ class NmdcServerClient extends FetchClient {
   }
 
   async updateSubmission(id: string, data: Partial<SubmissionMetadata>) {
-    return this.json<SubmissionMetadata>(`/metadata_submission/${id}`, {
+    return this.fetchJson<SubmissionMetadata>(`/metadata_submission/${id}`, {
       method: "PATCH",
       body: JSON.stringify(data),
     });
   }
 
   async createSubmission(data: SubmissionMetadataCreate) {
-    return this.json<SubmissionMetadata>("/metadata_submission", {
+    return this.fetchJson<SubmissionMetadata>("/metadata_submission", {
       method: "POST",
       body: JSON.stringify(data),
     });
@@ -281,7 +281,7 @@ class NmdcServerClient extends FetchClient {
   }
 
   async getCurrentUser() {
-    return this.json<string>("/me");
+    return this.fetchJson<string>("/me");
   }
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -11,6 +11,41 @@ export interface Contributor {
   roles: string[];
 }
 
+export interface ContextForm {
+  datasetDoi: string;
+  dataGenerated: Nullable<boolean>;
+  facilityGenerated: Nullable<boolean>;
+  facilities: string[];
+  award: Nullable<string>;
+  otherAward: string;
+}
+
+export interface Address {
+  name: string;
+  email: string;
+  phone: string;
+  line1: string;
+  line2: string;
+  city: string;
+  state: string;
+  postalCode: string;
+}
+
+export interface AddressForm {
+  shipper: Address;
+  expectedShippingDate: Nullable<Date>;
+  shippingConditions: string;
+  sample: string;
+  description: string;
+  experimentalGoals: string;
+  randomization: string;
+  usdaRegulated: Nullable<boolean>;
+  permitNumber: string;
+  biosafetyLevel: string;
+  irbOrHipaa: Nullable<boolean>;
+  comments: string;
+}
+
 export interface StudyForm {
   studyName: string;
   piName: string;
@@ -19,8 +54,17 @@ export interface StudyForm {
   linkOutWebpage: string[];
   studyDate: Nullable<string>;
   description: string;
-  notes?: string;
+  notes: string;
   contributors: Contributor[];
+}
+
+export interface MultiOmicsForm {
+  alternativeNames: string[];
+  studyNumber: string;
+  GOLDStudyId: string;
+  JGIStudyId: string;
+  NCBIBioProjectId: string;
+  omicsProcessingTypes: string[];
 }
 
 export interface SampleData {
@@ -28,14 +72,78 @@ export interface SampleData {
   [key: string]: string | number;
 }
 
-// TODO: replace the `object` types with the actual types
+// This should eventually come from the schema itself
+// See: https://github.com/microbiomedata/submission-schema/issues/186
+export interface TemplateInfo {
+  displayName: string;
+  schemaClass?: string;
+  sampleDataSlot?: string;
+}
+export const TEMPLATES: Record<string, TemplateInfo> = {
+  air: {
+    displayName: "air",
+    schemaClass: "AirInterface",
+    sampleDataSlot: "air_data",
+  },
+  "built environment": {
+    displayName: "built environment",
+    schemaClass: "BuiltEnvInterface",
+    sampleDataSlot: "built_env_data",
+  },
+  "host-associated": {
+    displayName: "host-associated",
+    schemaClass: "HostAssociatedInterface",
+    sampleDataSlot: "host_associated_data",
+  },
+  "hydrocarbon resources-cores": {
+    displayName: "hydrocarbon resources - cores",
+    schemaClass: "HcrCoresInterface",
+    sampleDataSlot: "hcr_cores_data",
+  },
+  "hydrocarbon resources-fluids_swabs": {
+    displayName: "hydrocarbon resources - fluids swabs",
+    schemaClass: "HcrFluidsSwabsInterface",
+    sampleDataSlot: "hcr_fluids_swabs_data",
+  },
+  "microbial mat_biofilm": {
+    displayName: "microbial mat_biofilm",
+    schemaClass: "BiofilmInterface",
+    sampleDataSlot: "biofilm_data",
+  },
+  "miscellaneous natural or artificial environment": {
+    displayName: "miscellaneous natural or artificial environment",
+    schemaClass: "MiscEnvsInterface",
+    sampleDataSlot: "misc_envs_data",
+  },
+  "plant-associated": {
+    displayName: "plant-associated",
+    schemaClass: "PlantAssociatedInterface",
+    sampleDataSlot: "plant_associated_data",
+  },
+  sediment: {
+    displayName: "sediment",
+    schemaClass: "SedimentInterface",
+    sampleDataSlot: "sediment_data",
+  },
+  soil: {
+    displayName: "soil",
+    schemaClass: "SoilInterface",
+    sampleDataSlot: "soil_data",
+  },
+  water: {
+    displayName: "water",
+    schemaClass: "WaterInterface",
+    sampleDataSlot: "water_data",
+  },
+};
+
 export interface MetadataSubmission {
-  packageName: string;
-  contextForm: object;
-  addressForm: object;
+  packageName: keyof typeof TEMPLATES;
+  contextForm: ContextForm;
+  addressForm: AddressForm;
   templates: string[];
   studyForm: StudyForm;
-  multiOmicsForm: object;
+  multiOmicsForm: MultiOmicsForm;
   sampleData: Record<string, SampleData[]>;
 }
 
@@ -46,8 +154,11 @@ export interface User {
   is_admin: boolean;
 }
 
-export interface SubmissionMetadata {
+export interface SubmissionMetadataCreate {
   metadata_submission: MetadataSubmission;
+}
+
+export interface SubmissionMetadata extends SubmissionMetadataCreate {
   status: string;
   id: string;
   author_orcid: string;
@@ -156,7 +267,7 @@ class NmdcServerClient extends FetchClient {
     });
   }
 
-  async createSubmission(data: DeepPartial<SubmissionMetadata>) {
+  async createSubmission(data: SubmissionMetadataCreate) {
     return this.json<SubmissionMetadata>("/metadata_submission", {
       method: "POST",
       body: JSON.stringify(data),

--- a/src/components/StudyForm/StudyForm.module.css
+++ b/src/components/StudyForm/StudyForm.module.css
@@ -1,0 +1,4 @@
+.errorMessage {
+  font-size: 0.75rem;
+  color: var(--ion-color-danger);
+}

--- a/src/components/StudyForm/StudyForm.tsx
+++ b/src/components/StudyForm/StudyForm.tsx
@@ -1,0 +1,211 @@
+import React from "react";
+import {
+  IonButton,
+  IonInput,
+  IonSelect,
+  IonSelectOption,
+  IonText,
+  IonTextarea,
+} from "@ionic/react";
+import SectionHeader from "../SectionHeader/SectionHeader";
+import { SubmissionMetadataCreate, TEMPLATES } from "../../api";
+import { Controller, useForm } from "react-hook-form";
+
+import styles from "./StudyForm.module.css";
+
+interface StudyFormProps {
+  submission: SubmissionMetadataCreate;
+  onSave: (submission: SubmissionMetadataCreate) => Promise<unknown>;
+}
+
+const EMAIL_REGEX =
+  /^(?!\.)(?!.*\.\.)([A-Z0-9_+-.]*)[A-Z0-9_+-]@([A-Z0-9][A-Z0-9-]*\.)+[A-Z]{2,}$/i;
+
+const StudyForm: React.FC<StudyFormProps> = ({ submission, onSave }) => {
+  const { handleSubmit, control, formState, setValue } =
+    useForm<SubmissionMetadataCreate>({
+      defaultValues: submission,
+      mode: "onTouched",
+      reValidateMode: "onChange",
+    });
+
+  return (
+    <form onSubmit={handleSubmit(onSave)}>
+      <div className="ion-padding">
+        <Controller
+          name="metadata_submission.studyForm.studyName"
+          rules={{ required: "This field is required" }}
+          control={control}
+          render={({ field, fieldState }) => {
+            return (
+              <IonInput
+                className={`${(fieldState.isTouched || formState.isSubmitted) && "ion-touched"} ${fieldState.invalid && "ion-invalid"}`}
+                labelPlacement="floating"
+                helperText="Provide a study name to associate with your samples."
+                errorText={fieldState.error?.message}
+                type="text"
+                onIonBlur={field.onBlur}
+                onIonInput={field.onChange}
+                {...field}
+              >
+                <div slot="label">
+                  Name<IonText color="danger">*</IonText>
+                </div>
+              </IonInput>
+            );
+          }}
+        />
+
+        <Controller
+          name="metadata_submission.studyForm.description"
+          control={control}
+          render={({ field, fieldState }) => (
+            <IonTextarea
+              className={`${(fieldState.isTouched || formState.isSubmitted) && "ion-touched"} ${fieldState.invalid && "ion-invalid"}`}
+              label="Description"
+              helperText="Provide a description of your study. This should include some general context of your research goals and study design."
+              labelPlacement="floating"
+              autoGrow
+              onIonBlur={field.onBlur}
+              onIonInput={field.onChange}
+              {...field}
+            />
+          )}
+        />
+
+        <Controller
+          name="metadata_submission.studyForm.notes"
+          control={control}
+          render={({ field, fieldState }) => (
+            <IonTextarea
+              className={`${(fieldState.isTouched || formState.isSubmitted) && "ion-touched"} ${fieldState.invalid && "ion-invalid"}`}
+              label="Notes"
+              helperText="Add any additional notes or comments about this study."
+              labelPlacement="floating"
+              autoGrow
+              onIonBlur={field.onBlur}
+              onIonInput={field.onChange}
+              {...field}
+            />
+          )}
+        />
+      </div>
+
+      <SectionHeader>Principal Investigator</SectionHeader>
+
+      <div className="ion-padding">
+        <Controller
+          name="metadata_submission.studyForm.piName"
+          control={control}
+          render={({ field, fieldState }) => (
+            <IonInput
+              className={`${(fieldState.isTouched || formState.isSubmitted) && "ion-touched"} ${fieldState.invalid && "ion-invalid"}`}
+              label="Name"
+              helperText="The Principal Investigator who led the study and/or generated the data."
+              labelPlacement="floating"
+              type="text"
+              onIonBlur={field.onBlur}
+              onIonInput={field.onChange}
+              {...field}
+            />
+          )}
+        />
+
+        <Controller
+          name="metadata_submission.studyForm.piEmail"
+          control={control}
+          rules={{
+            required: "This field is required",
+            validate: {
+              validEmail: (value: string) =>
+                EMAIL_REGEX.test(value) || "Not a valid email address",
+            },
+          }}
+          render={({ field, fieldState }) => (
+            <IonInput
+              className={`${(fieldState.isTouched || formState.isSubmitted) && "ion-touched"} ${fieldState.invalid && "ion-invalid"}`}
+              helperText="An email address for the Principal Investigator."
+              errorText={fieldState.error?.message}
+              labelPlacement="floating"
+              type="text"
+              onIonBlur={field.onBlur}
+              onIonInput={field.onChange}
+              {...field}
+            >
+              <div slot="label">
+                Email<IonText color="danger">*</IonText>
+              </div>
+            </IonInput>
+          )}
+        />
+
+        <Controller
+          name="metadata_submission.studyForm.piOrcid"
+          control={control}
+          render={({ field, fieldState }) => (
+            <IonInput
+              className={`${(fieldState.isTouched || formState.isSubmitted) && "ion-touched"} ${fieldState.invalid && "ion-invalid"}`}
+              label="ORCID iD"
+              helperText="ORCID iD of the Principal Investigator.."
+              labelPlacement="floating"
+              type="text"
+              onIonBlur={field.onBlur}
+              onIonInput={field.onChange}
+              {...field}
+            />
+          )}
+        />
+      </div>
+
+      <SectionHeader>Environment</SectionHeader>
+
+      <div className="ion-padding">
+        <Controller
+          name="metadata_submission.packageName"
+          rules={{ required: "This field is required" }}
+          control={control}
+          render={({ field, fieldState }) => (
+            <>
+              <IonSelect
+                className={`${(fieldState.isTouched || formState.isSubmitted) && "ion-touched"} ${fieldState.invalid && "ion-invalid"}`}
+                labelPlacement="floating"
+                onIonDismiss={field.onBlur}
+                onIonChange={(e) => {
+                  // these two fields need to stay in sync
+                  setValue("metadata_submission.templates.0", e.detail.value);
+                  field.onChange(e.detail.value);
+                }}
+                {...field}
+              >
+                <div slot="label">
+                  Template<IonText color="danger">*</IonText>
+                </div>
+                {Object.entries(TEMPLATES).map(([key, template]) => (
+                  <IonSelectOption value={key} key={key}>
+                    {template.displayName}
+                  </IonSelectOption>
+                ))}
+              </IonSelect>
+              {fieldState.error && (
+                <IonText className={styles.errorMessage}>
+                  <span>{fieldState.error.message}</span>
+                </IonText>
+              )}
+            </>
+          )}
+        />
+
+        <IonButton
+          expand="block"
+          className="ion-margin-top"
+          type="submit"
+          disabled={formState.isDirty && !formState.isValid}
+        >
+          {formState.isSubmitting ? "Saving" : "Save"}
+        </IonButton>
+      </div>
+    </form>
+  );
+};
+
+export default StudyForm;

--- a/src/components/StudyForm/StudyForm.tsx
+++ b/src/components/StudyForm/StudyForm.tsx
@@ -18,6 +18,17 @@ interface StudyFormProps {
   onSave: (submission: SubmissionMetadataCreate) => Promise<unknown>;
 }
 
+// Based on the email validator from https://zod.dev/
+// Allows:
+//   - name@example.org
+//   - first.last@example.org
+//   - name@example.co
+// Disallows:
+//   - name@example
+//   - name@example.c
+//   - first..last@example.org
+//   - .name@example.org
+//   - name.@example.org
 const EMAIL_REGEX =
   /^(?!\.)(?!.*\.\.)([A-Z0-9_+-.]*)[A-Z0-9_+-]@([A-Z0-9][A-Z0-9-]*\.)+[A-Z]{2,}$/i;
 

--- a/src/components/StudyForm/StudyForm.tsx
+++ b/src/components/StudyForm/StudyForm.tsx
@@ -157,7 +157,7 @@ const StudyForm: React.FC<StudyFormProps> = ({ submission, onSave }) => {
             <IonInput
               className={`${(fieldState.isTouched || formState.isSubmitted) && "ion-touched"} ${fieldState.invalid && "ion-invalid"}`}
               label="ORCID iD"
-              helperText="ORCID iD of the Principal Investigator.."
+              helperText="ORCID iD of the Principal Investigator."
               labelPlacement="floating"
               type="text"
               onIonBlur={field.onBlur}

--- a/src/data.ts
+++ b/src/data.ts
@@ -8,7 +8,7 @@ import {
   SubmissionMetadataCreate,
 } from "./api";
 
-export const defaultAddress = (): Address => ({
+export const initAddress = (): Address => ({
   city: "",
   email: "",
   line1: "",
@@ -19,7 +19,7 @@ export const defaultAddress = (): Address => ({
   state: "",
 });
 
-export const defaultAddressForm = (): AddressForm => ({
+export const initAddressForm = (): AddressForm => ({
   biosafetyLevel: "",
   comments: "",
   description: "",
@@ -29,12 +29,12 @@ export const defaultAddressForm = (): AddressForm => ({
   permitNumber: "",
   randomization: "",
   sample: "",
-  shipper: defaultAddress(),
+  shipper: initAddress(),
   shippingConditions: "",
   usdaRegulated: null,
 });
 
-export const defaultContextForm = (): ContextForm => ({
+export const initContextForm = (): ContextForm => ({
   award: null,
   dataGenerated: null,
   datasetDoi: "",
@@ -43,7 +43,7 @@ export const defaultContextForm = (): ContextForm => ({
   otherAward: "",
 });
 
-export const defaultStudyForm = (): StudyForm => ({
+export const initStudyForm = (): StudyForm => ({
   contributors: [],
   description: "",
   linkOutWebpage: [],
@@ -55,7 +55,7 @@ export const defaultStudyForm = (): StudyForm => ({
   notes: "",
 });
 
-export const defaultMultiOmicsForm = (): MultiOmicsForm => ({
+export const initMultiOmicsForm = (): MultiOmicsForm => ({
   GOLDStudyId: "",
   JGIStudyId: "",
   NCBIBioProjectId: "",
@@ -64,16 +64,16 @@ export const defaultMultiOmicsForm = (): MultiOmicsForm => ({
   studyNumber: "",
 });
 
-export const defaultMetadataSubmission = (): MetadataSubmission => ({
-  addressForm: defaultAddressForm(),
-  contextForm: defaultContextForm(),
-  multiOmicsForm: defaultMultiOmicsForm(),
+export const initMetadataSubmission = (): MetadataSubmission => ({
+  addressForm: initAddressForm(),
+  contextForm: initContextForm(),
+  multiOmicsForm: initMultiOmicsForm(),
   packageName: "",
   sampleData: {},
-  studyForm: defaultStudyForm(),
+  studyForm: initStudyForm(),
   templates: [],
 });
 
-export const defaultSubmission = (): SubmissionMetadataCreate => ({
-  metadata_submission: defaultMetadataSubmission(),
+export const initSubmission = (): SubmissionMetadataCreate => ({
+  metadata_submission: initMetadataSubmission(),
 });

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,0 +1,79 @@
+import {
+  Address,
+  AddressForm,
+  ContextForm,
+  MetadataSubmission,
+  MultiOmicsForm,
+  StudyForm,
+  SubmissionMetadataCreate,
+} from "./api";
+
+export const defaultAddress = (): Address => ({
+  city: "",
+  email: "",
+  line1: "",
+  line2: "",
+  name: "",
+  phone: "",
+  postalCode: "",
+  state: "",
+});
+
+export const defaultAddressForm = (): AddressForm => ({
+  biosafetyLevel: "",
+  comments: "",
+  description: "",
+  expectedShippingDate: null,
+  experimentalGoals: "",
+  irbOrHipaa: null,
+  permitNumber: "",
+  randomization: "",
+  sample: "",
+  shipper: defaultAddress(),
+  shippingConditions: "",
+  usdaRegulated: null,
+});
+
+export const defaultContextForm = (): ContextForm => ({
+  award: null,
+  dataGenerated: null,
+  datasetDoi: "",
+  facilities: [],
+  facilityGenerated: null,
+  otherAward: "",
+});
+
+export const defaultStudyForm = (): StudyForm => ({
+  contributors: [],
+  description: "",
+  linkOutWebpage: [],
+  piEmail: "",
+  piName: "",
+  piOrcid: "",
+  studyDate: undefined,
+  studyName: "",
+  notes: "",
+});
+
+export const defaultMultiOmicsForm = (): MultiOmicsForm => ({
+  GOLDStudyId: "",
+  JGIStudyId: "",
+  NCBIBioProjectId: "",
+  alternativeNames: [],
+  omicsProcessingTypes: [],
+  studyNumber: "",
+});
+
+export const defaultMetadataSubmission = (): MetadataSubmission => ({
+  addressForm: defaultAddressForm(),
+  contextForm: defaultContextForm(),
+  multiOmicsForm: defaultMultiOmicsForm(),
+  packageName: "",
+  sampleData: {},
+  studyForm: defaultStudyForm(),
+  templates: [],
+});
+
+export const defaultSubmission = (): SubmissionMetadataCreate => ({
+  metadata_submission: defaultMetadataSubmission(),
+});

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,1 +1,5 @@
 type Nullable<T> = T | null | undefined;
+
+type DeepPartial<T> = {
+  [P in keyof T]?: DeepPartial<T[P]>;
+};

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,5 +1,1 @@
 type Nullable<T> = T | null | undefined;
-
-type DeepPartial<T> = {
-  [P in keyof T]?: DeepPartial<T[P]>;
-};

--- a/src/mocks/fixtures.ts
+++ b/src/mocks/fixtures.ts
@@ -1,9 +1,5 @@
 import { SubmissionMetadata } from "../api";
-import {
-  defaultAddressForm,
-  defaultContextForm,
-  defaultMultiOmicsForm,
-} from "../data";
+import { initAddressForm, initContextForm, initMultiOmicsForm } from "../data";
 
 export function generateSubmission(
   numberOfSamples: number,
@@ -21,9 +17,9 @@ export function generateSubmission(
     author_orcid: "0000-0000-0000-0000",
     metadata_submission: {
       packageName: "soil",
-      multiOmicsForm: defaultMultiOmicsForm(),
-      contextForm: defaultContextForm(),
-      addressForm: defaultAddressForm(),
+      multiOmicsForm: initMultiOmicsForm(),
+      contextForm: initContextForm(),
+      addressForm: initAddressForm(),
       templates: ["soil"],
       studyForm: {
         studyName: "",

--- a/src/mocks/fixtures.ts
+++ b/src/mocks/fixtures.ts
@@ -1,5 +1,39 @@
 import { SubmissionMetadata } from "../api";
 
+export function generateEmptySubmission(): SubmissionMetadata {
+  return {
+    author: {
+      id: "",
+      is_admin: false,
+      name: "",
+      orcid: "",
+    },
+    author_orcid: "",
+    created: "",
+    locked_by: undefined,
+    status: "",
+    id: "",
+    metadata_submission: {
+      packageName: "",
+      contextForm: {},
+      addressForm: {},
+      templates: [],
+      studyForm: {
+        studyName: "",
+        piName: "",
+        piEmail: "",
+        piOrcid: "",
+        linkOutWebpage: [],
+        studyDate: "",
+        description: "",
+        contributors: [],
+      },
+      multiOmicsForm: {},
+      sampleData: {},
+    },
+  };
+}
+
 export function generateSubmission(numberOfSamples: number) {
   return {
     id: "1",

--- a/src/mocks/fixtures.ts
+++ b/src/mocks/fixtures.ts
@@ -1,40 +1,13 @@
 import { SubmissionMetadata } from "../api";
+import {
+  defaultAddressForm,
+  defaultContextForm,
+  defaultMultiOmicsForm,
+} from "../data";
 
-export function generateEmptySubmission(): SubmissionMetadata {
-  return {
-    author: {
-      id: "",
-      is_admin: false,
-      name: "",
-      orcid: "",
-    },
-    author_orcid: "",
-    created: "",
-    locked_by: undefined,
-    status: "",
-    id: "",
-    metadata_submission: {
-      packageName: "",
-      contextForm: {},
-      addressForm: {},
-      templates: [],
-      studyForm: {
-        studyName: "",
-        piName: "",
-        piEmail: "",
-        piOrcid: "",
-        linkOutWebpage: [],
-        studyDate: "",
-        description: "",
-        contributors: [],
-      },
-      multiOmicsForm: {},
-      sampleData: {},
-    },
-  };
-}
-
-export function generateSubmission(numberOfSamples: number) {
+export function generateSubmission(
+  numberOfSamples: number,
+): SubmissionMetadata {
   return {
     id: "1",
     author: {
@@ -48,9 +21,9 @@ export function generateSubmission(numberOfSamples: number) {
     author_orcid: "0000-0000-0000-0000",
     metadata_submission: {
       packageName: "soil",
-      multiOmicsForm: {},
-      contextForm: {},
-      addressForm: {},
+      multiOmicsForm: defaultMultiOmicsForm(),
+      contextForm: defaultContextForm(),
+      addressForm: defaultAddressForm(),
       templates: ["soil"],
       studyForm: {
         studyName: "",
@@ -61,6 +34,7 @@ export function generateSubmission(numberOfSamples: number) {
         studyDate: undefined,
         description: "",
         contributors: [],
+        notes: "",
       },
       sampleData: {
         soil_data: Array.from({ length: numberOfSamples }, (_, i) => ({

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -3,7 +3,7 @@ import { Paginated, SubmissionMetadata } from "../api";
 import { submissions as submissionsFixture } from "./fixtures";
 import { setupServer } from "msw/node";
 import config from "../config";
-import { defaultSubmission } from "../data";
+import { initSubmission } from "../data";
 
 const { NMDC_SERVER_API_URL } = config;
 
@@ -55,7 +55,7 @@ export const handlers = [
         lock_updated: "",
         locked_by: undefined,
         status: "",
-        ...defaultSubmission(),
+        ...initSubmission(),
       };
       // TODO: this should be a true deep merge between the empty submission and the incoming body,
       // But for now this is good enough for the tests

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -1,11 +1,9 @@
 import { delay, http, HttpResponse } from "msw";
 import { Paginated, SubmissionMetadata } from "../api";
-import {
-  generateEmptySubmission,
-  submissions as submissionsFixture,
-} from "./fixtures";
+import { submissions as submissionsFixture } from "./fixtures";
 import { setupServer } from "msw/node";
 import config from "../config";
+import { defaultSubmission } from "../data";
 
 const { NMDC_SERVER_API_URL } = config;
 
@@ -40,22 +38,35 @@ export const handlers = [
       });
     },
   ),
-  http.post<
-    Record<never, never>,
-    DeepPartial<SubmissionMetadata>,
-    SubmissionMetadata
-  >(`${NMDC_SERVER_API_URL}/metadata_submission`, async ({ request }) => {
-    const body = await request.json();
-    const submission = generateEmptySubmission();
-    // TODO: this should be a true deep merge between the empty submission and the incoming body,
-    // But for now this is good enough for the tests
-    submission.metadata_submission.studyForm.studyName =
-      body.metadata_submission?.studyForm?.studyName || "";
-    submission.metadata_submission.studyForm.piEmail =
-      body.metadata_submission?.studyForm?.piEmail || "";
-    submissions.push(submission);
-    return HttpResponse.json(submission);
-  }),
+  http.post<Record<never, never>, SubmissionMetadata, SubmissionMetadata>(
+    `${NMDC_SERVER_API_URL}/metadata_submission`,
+    async ({ request }) => {
+      const body = await request.json();
+      const submission: SubmissionMetadata = {
+        author: {
+          id: "",
+          orcid: "",
+          name: "",
+          is_admin: false,
+        },
+        author_orcid: "",
+        created: "",
+        id: "",
+        lock_updated: "",
+        locked_by: undefined,
+        status: "",
+        ...defaultSubmission(),
+      };
+      // TODO: this should be a true deep merge between the empty submission and the incoming body,
+      // But for now this is good enough for the tests
+      submission.metadata_submission.studyForm.studyName =
+        body.metadata_submission?.studyForm?.studyName || "";
+      submission.metadata_submission.studyForm.piEmail =
+        body.metadata_submission?.studyForm?.piEmail || "";
+      submissions.push(submission);
+      return HttpResponse.json(submission);
+    },
+  ),
   http.delete<{ id: string }>(
     `${NMDC_SERVER_API_URL}/metadata_submission/:id`,
     async ({ params }) => {

--- a/src/pages/StudyCreatePage/StudyCreatePage.tsx
+++ b/src/pages/StudyCreatePage/StudyCreatePage.tsx
@@ -15,6 +15,7 @@ import { useSubmissionCreate } from "../../queries";
 import { SubmissionMetadataCreate } from "../../api";
 import { paths } from "../../Router";
 import { defaultSubmission } from "../../data";
+import { checkmark } from "ionicons/icons";
 
 const StudyCreatePage: React.FC = () => {
   const router = useIonRouter();
@@ -28,7 +29,7 @@ const StudyCreatePage: React.FC = () => {
         present({
           message: "Study created",
           duration: 3000,
-          color: "success",
+          icon: checkmark,
         });
         router.push(paths.studyView(created.id), "forward", "replace");
       },

--- a/src/pages/StudyCreatePage/StudyCreatePage.tsx
+++ b/src/pages/StudyCreatePage/StudyCreatePage.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import {
   IonBackButton,
   IonButtons,
@@ -7,9 +7,34 @@ import {
   IonPage,
   IonTitle,
   IonToolbar,
+  useIonRouter,
+  useIonToast,
 } from "@ionic/react";
+import StudyForm from "../../components/StudyForm/StudyForm";
+import { useSubmissionCreate } from "../../queries";
+import { SubmissionMetadataCreate } from "../../api";
+import { paths } from "../../Router";
+import { defaultSubmission } from "../../data";
 
 const StudyCreatePage: React.FC = () => {
+  const router = useIonRouter();
+  const [present] = useIonToast();
+  const submissionCreate = useSubmissionCreate();
+  const submission = useMemo(defaultSubmission, []);
+
+  const handleSave = async (submission: SubmissionMetadataCreate) => {
+    submissionCreate.mutate(submission, {
+      onSuccess: (created) => {
+        present({
+          message: "Study created",
+          duration: 3000,
+          color: "success",
+        });
+        router.push(paths.studyView(created.id), "forward", "replace");
+      },
+    });
+  };
+
   return (
     <IonPage>
       <IonHeader>
@@ -21,7 +46,7 @@ const StudyCreatePage: React.FC = () => {
         </IonToolbar>
       </IonHeader>
       <IonContent>
-        <h2>New Study</h2>
+        <StudyForm submission={submission} onSave={handleSave} />
       </IonContent>
     </IonPage>
   );

--- a/src/pages/StudyCreatePage/StudyCreatePage.tsx
+++ b/src/pages/StudyCreatePage/StudyCreatePage.tsx
@@ -14,14 +14,14 @@ import StudyForm from "../../components/StudyForm/StudyForm";
 import { useSubmissionCreate } from "../../queries";
 import { SubmissionMetadataCreate } from "../../api";
 import { paths } from "../../Router";
-import { defaultSubmission } from "../../data";
+import { initSubmission } from "../../data";
 import { checkmark } from "ionicons/icons";
 
 const StudyCreatePage: React.FC = () => {
   const router = useIonRouter();
   const [present] = useIonToast();
   const submissionCreate = useSubmissionCreate();
-  const submission = useMemo(defaultSubmission, []);
+  const submission = useMemo(initSubmission, []);
 
   const handleSave = async (submission: SubmissionMetadataCreate) => {
     submissionCreate.mutate(submission, {

--- a/src/pages/StudyEditPage/StudyEditPage.tsx
+++ b/src/pages/StudyEditPage/StudyEditPage.tsx
@@ -22,7 +22,11 @@ import { paths } from "../../Router";
 import StudyForm from "../../components/StudyForm/StudyForm";
 import { useSubmission } from "../../queries";
 import { SubmissionMetadata, SubmissionMetadataCreate } from "../../api";
-import { ellipsisHorizontal, ellipsisVertical } from "ionicons/icons";
+import {
+  checkmark,
+  ellipsisHorizontal,
+  ellipsisVertical,
+} from "ionicons/icons";
 
 interface StudyEditPageParams {
   submissionId: string;
@@ -45,7 +49,7 @@ const StudyEditPage: React.FC = () => {
         presentToast({
           message: "Study updated",
           duration: 3000,
-          color: "success",
+          icon: checkmark,
         });
       },
     });

--- a/src/pages/StudyEditPage/StudyEditPage.tsx
+++ b/src/pages/StudyEditPage/StudyEditPage.tsx
@@ -5,18 +5,38 @@ import {
   IonContent,
   IonHeader,
   IonPage,
+  IonProgressBar,
   IonTitle,
   IonToolbar,
+  useIonToast,
 } from "@ionic/react";
 import { useParams } from "react-router";
 import { paths } from "../../Router";
+import StudyForm from "../../components/StudyForm/StudyForm";
+import { useSubmission } from "../../queries";
+import { SubmissionMetadata, SubmissionMetadataCreate } from "../../api";
 
 interface StudyEditPageParams {
   submissionId: string;
 }
 
 const StudyEditPage: React.FC = () => {
+  const [present] = useIonToast();
   const { submissionId } = useParams<StudyEditPageParams>();
+  const { query: submission, update } = useSubmission(submissionId);
+
+  const handleSave = async (submission: SubmissionMetadataCreate) => {
+    update.mutate(submission as SubmissionMetadata, {
+      onSuccess: () => {
+        present({
+          message: "Study updated",
+          duration: 3000,
+          color: "success",
+        });
+      },
+    });
+  };
+
   return (
     <IonPage>
       <IonHeader>
@@ -30,7 +50,18 @@ const StudyEditPage: React.FC = () => {
         </IonToolbar>
       </IonHeader>
       <IonContent>
-        <h2>{submissionId}</h2>
+        <IonProgressBar
+          type="indeterminate"
+          style={{
+            visibility:
+              submission.isFetching || submission.isLoading
+                ? "visible"
+                : "hidden",
+          }}
+        />
+        {submission.data && (
+          <StudyForm submission={submission.data} onSave={handleSave} />
+        )}
       </IonContent>
     </IonPage>
   );

--- a/src/queries.test.tsx
+++ b/src/queries.test.tsx
@@ -14,6 +14,7 @@ import {
 } from "./queries";
 import { produce } from "immer";
 import { patchMetadataSubmissionError, server, delay } from "./mocks/server";
+import { defaultSubmission } from "./data";
 
 interface TestWrapperProps {
   children: ReactNode;
@@ -282,15 +283,11 @@ test("useSubmissionCreate should create submission", async () => {
   const { result } = renderHook(() => useSubmissionCreate(), { wrapper });
 
   // Create a new submission
+  const newSubmission = defaultSubmission();
+  newSubmission.metadata_submission.studyForm.studyName = "New Study";
+  newSubmission.metadata_submission.studyForm.piEmail = "test@fake.org";
   await act(() => {
-    return result.current.mutateAsync({
-      metadata_submission: {
-        studyForm: {
-          studyName: "New Study",
-          piEmail: "test@fake.org",
-        },
-      },
-    });
+    return result.current.mutateAsync(newSubmission);
   });
 
   // Ensure that the mutation completes successfully and that the submission is in the list

--- a/src/queries.test.tsx
+++ b/src/queries.test.tsx
@@ -106,12 +106,12 @@ test("useSubmission should mutate data", async () => {
     draft.metadata_submission.studyForm.studyName = "UPDATED";
   });
   await act(() => {
-    result.current.update.mutate(updatedSubmission);
+    result.current.updateMutation.mutate(updatedSubmission);
     return delay(10);
   });
   // Verify that the mutation has optimistically updated the data
   expect(
-    result.current.update.data?.metadata_submission.studyForm.studyName,
+    result.current.updateMutation.data?.metadata_submission.studyForm.studyName,
   ).toBe("UPDATED");
   expect(
     result.current.query.data?.metadata_submission.studyForm.studyName,
@@ -119,10 +119,12 @@ test("useSubmission should mutate data", async () => {
 
   // Once the mutation completes, ensure that both the mutation, query, and list query still return
   // the updated data
-  await waitFor(() => expect(result.current.update.isSuccess).toBe(true));
-  expect(result.current.update.data).toBeDefined();
+  await waitFor(() =>
+    expect(result.current.updateMutation.isSuccess).toBe(true),
+  );
+  expect(result.current.updateMutation.data).toBeDefined();
   expect(
-    result.current.update.data?.metadata_submission.studyForm.studyName,
+    result.current.updateMutation.data?.metadata_submission.studyForm.studyName,
   ).toBe("UPDATED");
   expect(
     result.current.query.data?.metadata_submission.studyForm.studyName,
@@ -165,7 +167,7 @@ test("useSubmission should replace paused mutations when offline", async () => {
   // waits for the entire request to go through successfully which won't happen here because we're
   // offline. So instead just pause for a very short duration.
   await act(() => {
-    result.current.update.mutate(update1);
+    result.current.updateMutation.mutate(update1);
     return delay(10);
   });
 
@@ -173,14 +175,16 @@ test("useSubmission should replace paused mutations when offline", async () => {
     draft.metadata_submission.studyForm.studyName = "UPDATE 2";
   });
   await act(() => {
-    result.current.update.mutate(update2);
+    result.current.updateMutation.mutate(update2);
     return delay(10);
   });
 
   // Go back online, ensure that the mutation successfully completes, that only one PATCH
   // request was sent, and that the final data is correct.
   onlineManager.setOnline(true);
-  await waitFor(() => expect(result.current.update.isSuccess).toBe(true));
+  await waitFor(() =>
+    expect(result.current.updateMutation.isSuccess).toBe(true),
+  );
   expect(patchCount).toBe(1);
   expect(
     result.current.query.data?.metadata_submission.studyForm.studyName,
@@ -211,7 +215,7 @@ test("useSubmission should rollback optimistic updates if a mutation fails", asy
     draft.metadata_submission.studyForm.studyName = "UPDATED";
   });
   await act(() => {
-    result.current.update.mutate(updatedSubmission);
+    result.current.updateMutation.mutate(updatedSubmission);
     return delay(10);
   });
   // Verify that the mutation has optimistically updated the data
@@ -221,7 +225,7 @@ test("useSubmission should rollback optimistic updates if a mutation fails", asy
 
   // Once the mutation completes (as failed), ensure that both the mutation, query, and list query
   // now return the rolled back data
-  await waitFor(() => expect(result.current.update.isError).toBe(true));
+  await waitFor(() => expect(result.current.updateMutation.isError).toBe(true));
   expect(
     result.current.query.data?.metadata_submission.studyForm.studyName,
   ).toBe("TEST 1");
@@ -254,12 +258,14 @@ test("useSubmission should delete submission", async () => {
 
   // Delete the submission
   await act(() => {
-    return result.current.delete.mutateAsync(TEST_ID_1);
+    return result.current.deleteMutation.mutateAsync(TEST_ID_1);
   });
 
   // Ensure that the mutation completes successfully and that the submission is no longer in the
   // list
-  await waitFor(() => expect(result.current.delete.isSuccess).toBe(true));
+  await waitFor(() =>
+    expect(result.current.deleteMutation.isSuccess).toBe(true),
+  );
   listRerender();
   expect(
     listResult.current.data?.pages[0].results.find(

--- a/src/queries.test.tsx
+++ b/src/queries.test.tsx
@@ -14,7 +14,7 @@ import {
 } from "./queries";
 import { produce } from "immer";
 import { patchMetadataSubmissionError, server, delay } from "./mocks/server";
-import { defaultSubmission } from "./data";
+import { initSubmission } from "./data";
 
 interface TestWrapperProps {
   children: ReactNode;
@@ -289,7 +289,7 @@ test("useSubmissionCreate should create submission", async () => {
   const { result } = renderHook(() => useSubmissionCreate(), { wrapper });
 
   // Create a new submission
-  const newSubmission = defaultSubmission();
+  const newSubmission = initSubmission();
   newSubmission.metadata_submission.studyForm.studyName = "New Study";
   newSubmission.metadata_submission.studyForm.piEmail = "test@fake.org";
   await act(() => {

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -182,15 +182,15 @@ export function useSubmission(id: string) {
   const deleteMutation = useMutation<void, DefaultError, string>({
     mutationKey: submissionKeys.delete(id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: submissionKeys.detail(id) });
+      queryClient.removeQueries({ queryKey: submissionKeys.detail(id) });
       queryClient.invalidateQueries({ queryKey: submissionKeys.list() });
     },
   });
 
   return {
     query,
-    update: updateMutation,
-    delete: deleteMutation,
+    updateMutation,
+    deleteMutation,
   };
 }
 

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -8,7 +8,12 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import { Paginated, SubmissionMetadata, nmdcServerClient } from "./api";
+import {
+  Paginated,
+  SubmissionMetadata,
+  nmdcServerClient,
+  SubmissionMetadataCreate,
+} from "./api";
 import { produce } from "immer";
 
 export const userKeys = {
@@ -35,7 +40,7 @@ export function addDefaultMutationFns(queryClient: QueryClient) {
     },
   });
   queryClient.setMutationDefaults(submissionKeys.create(), {
-    mutationFn: async (newSubmission: DeepPartial<SubmissionMetadata>) => {
+    mutationFn: async (newSubmission: SubmissionMetadataCreate) => {
       await queryClient.cancelQueries({
         queryKey: submissionKeys.create(),
       });
@@ -194,7 +199,7 @@ export function useSubmissionCreate() {
   const mutation = useMutation<
     SubmissionMetadata,
     DefaultError,
-    DeepPartial<SubmissionMetadata>
+    SubmissionMetadataCreate
   >({
     mutationKey: submissionKeys.create(),
     onSuccess: () => {

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -18,8 +18,11 @@ export const userKeys = {
 export const submissionKeys = {
   all: () => ["submissions"],
   list: () => [...submissionKeys.all(), "list"],
+  create: () => [...submissionKeys.all(), "create"],
   details: () => [...submissionKeys.all(), "detail"],
   detail: (id: string) => [...submissionKeys.details(), id],
+  deletes: () => [...submissionKeys.details(), "delete"],
+  delete: (id: string) => [...submissionKeys.deletes(), id],
 };
 
 export function addDefaultMutationFns(queryClient: QueryClient) {
@@ -29,6 +32,22 @@ export function addDefaultMutationFns(queryClient: QueryClient) {
         queryKey: submissionKeys.detail(updated.id),
       });
       return nmdcServerClient.updateSubmission(updated.id, updated);
+    },
+  });
+  queryClient.setMutationDefaults(submissionKeys.create(), {
+    mutationFn: async (newSubmission: DeepPartial<SubmissionMetadata>) => {
+      await queryClient.cancelQueries({
+        queryKey: submissionKeys.create(),
+      });
+      return nmdcServerClient.createSubmission(newSubmission);
+    },
+  });
+  queryClient.setMutationDefaults(submissionKeys.deletes(), {
+    mutationFn: async (id: string) => {
+      await queryClient.cancelQueries({
+        queryKey: submissionKeys.delete(id),
+      });
+      return nmdcServerClient.deleteSubmission(id);
     },
   });
 }
@@ -113,7 +132,7 @@ export function useSubmission(id: string) {
   type SubmissionMetadataMutationContext = {
     previousData?: SubmissionMetadata;
   };
-  const mutation = useMutation<
+  const updateMutation = useMutation<
     SubmissionMetadata,
     DefaultError,
     SubmissionMetadata,
@@ -155,8 +174,32 @@ export function useSubmission(id: string) {
     },
   });
 
+  const deleteMutation = useMutation<void, DefaultError, string>({
+    mutationKey: submissionKeys.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: submissionKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: submissionKeys.list() });
+    },
+  });
+
   return {
     query,
-    mutation,
+    update: updateMutation,
+    delete: deleteMutation,
   };
+}
+
+export function useSubmissionCreate() {
+  const queryClient = useQueryClient();
+  const mutation = useMutation<
+    SubmissionMetadata,
+    DefaultError,
+    DeepPartial<SubmissionMetadata>
+  >({
+    mutationKey: submissionKeys.create(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: submissionKeys.list() });
+    },
+  });
+  return mutation;
 }


### PR DESCRIPTION
Fixes #45 

### Summary

These changes fill out the stub study create and study edit pages with real content. They both present a common study form component with basic validation. The edit page also includes a dropdown menu in the toolbar to initiate deleting a study.

### Details

* Add new dependency on [`react-hook-form`](https://react-hook-form.com/). I think most people have seen this library before (maybe?), so hopefully it doesn't need too much explanation. But this library provides form state management and validation. 
* Add methods to the `nmdc-server` client in `src/api.ts` for calling the `POST /api/metadata_submission` and `DELETE /api/metadata_submission/:id` endpoints. Since the `DELETE` endpoint returns a 204 response with an empty body I shuffled around the protected methods of `FetchClient` to avoid attempting to parse the body in that case.
* Add a new `useSubmissionCreate` hook which wraps `useMutation` and calls the `POST` endpoint method.
* Update the `useSubmission` hook to return a `deleteMutation` in addition to the existing `updateMutation` (which has been renamed from just `mutation`).
* Add a bunch more TypeScript interfaces to fully define the `MetadataSubmission` structure. Previously a lot of that structure was stubbed out with `object` types, and that was fine when we were only fetching data. We only needed to describe the parts that our application accessed. But now that we are sending data back to the server, we need to describe the whole structure. This is especially important because the backend application expects **everything** in the `metadata_submission` field to be filled out (even if it's just with empty strings or lists) when you create a new `SubmissionMetadata` record. Other top-level properties like `id` and `status` _don't_ need to be there, but the entire `metadata_submission` structure does. So that's also why there is a new `SubmissionMetadataCreate` interface that `SubmissionMetadata` now extends. `SubmissionMetadataCreate` describes what is necessary to create a `SubmissionMetadata` record and `SubmissionMetadata` describes the fully formed object you get back from the server.
* Add a new module (`src/data.ts`) with methods to generate a "blank" `SubmissionMetadataCreate` instance. 
* Add a new `StudyForm` component which displays the certain chosen fields within a `SubmissionMetadataCreate` instance and implements validation logic. The client of this component is responsible for providing the `SubmissionMetadataCreate` instance which provide the default form values and a callback that will be called when the user submits the form.
* Update the study edit page to fetch the submission, pass it to the the `StudyForm` component, and connect the submit callback to the appropriate mutation. This page also gets a dropdown menu in the toolbar for deleting a study.
* Update the study create page to generate a blank `SubmissionMetadataCreate` instance, pass it to the `StudyForm` component, and connect the submit callback to the appropriate mutation. 