### PR TITLE
Fix layout bug where hyperlink touches preceding text

### DIFF
--- a/src/components/Tutorial/Tutorial.tsx
+++ b/src/components/Tutorial/Tutorial.tsx
@@ -59,7 +59,7 @@ const Tutorial: React.FC = () => {
                       icon={checkmarkCircle}
                       color={"primary"}
                     />
-                    {props!.children as string}
+                    <span>{props!.children}</span>
                   </IonItem>
                 ),
               }}


### PR DESCRIPTION
In this branch, I fixed a layout bug causing text in a Markdown-powered list item to touch the hyperlink that followed it. The fix involved wrapping the list item's content in a `<span></span>` element. As a side effect, I was able to remove an obsolete (and unnecessarily restrictive) type hint.

Example list item (Markdown):
```diff
  const rawMarkdownContent = `
+ - Link to [example.com](https://www.example.com)
  - Way of measuring sampling depth e.g., ruler, measurement device
```

### Before

Here's how that list item is rendered when using the code in `main` today:

<img width="360" alt="image" src="https://github.com/microbiomedata/nmdc-field-notes/assets/134325062/7e020208-a8cc-46b4-94d3-2c5059852926">

### After

Here's how that list item is rendered when using the code in this PR branch:

<img width="360" alt="image" src="https://github.com/microbiomedata/nmdc-field-notes/assets/134325062/3141cff2-13cc-496a-b508-e6959e5082cf">