### PR TITLE
Add ability to delete samples

### DIFF
--- a/src/Validator.ts
+++ b/src/Validator.ts
@@ -341,9 +341,6 @@ class Validator {
     // be performed atomically on the value in the cell according to the column's
     // slot.
     for (let idx = 0; idx < data.length; idx += 1) {
-      if (!nonEmptyRowNumbers.includes(idx)) {
-        continue;
-      }
       for (const slotName of Object.keys(this.targetClassInducedSlots!)) {
         const valueValidator = this.getValidatorForSlot(slotName, {
           cacheKey: slotName,

--- a/src/components/StudyView/StudyView.tsx
+++ b/src/components/StudyView/StudyView.tsx
@@ -28,16 +28,13 @@ const StudyView: React.FC<StudyViewProps> = ({ submissionId }) => {
     }
     const updatedSubmission = produce(submission.data, (draft) => {
       const samples = getSubmissionSamples(draft);
-      samples.push({
-        _index: samples.length,
-      });
+      samples.push({});
     });
     updateMutation.mutate(updatedSubmission, {
       onSuccess: (result) => {
         const samples = getSubmissionSamples(result);
-        const lastSample = samples[samples.length - 1];
         router.push(
-          paths.sample(submissionId, lastSample._index.toString()),
+          paths.sample(submissionId, samples.length - 1),
           "forward",
           "push",
         );

--- a/src/mocks/fixtures.ts
+++ b/src/mocks/fixtures.ts
@@ -34,7 +34,6 @@ export function generateSubmission(
       },
       sampleData: {
         soil_data: Array.from({ length: numberOfSamples }, (_, i) => ({
-          _index: i,
           samp_name:
             (i % 3 === 0 ? "Silt" : i % 5 === 0 ? "Clay" : "Loam") + " " + i,
         })),

--- a/src/pages/SamplePage/SamplePage.tsx
+++ b/src/pages/SamplePage/SamplePage.tsx
@@ -93,9 +93,21 @@ const SamplePage: React.FC = () => {
           return;
         }
         if (result) {
-          draft[parseInt(sampleIndex)][modalSlot.name] = result;
+          // If the sample previously passed validation, its index won't be
+          // in `draft`. But it needs to be after this partial validation,
+          // so add a spot for it now.
+          if (!(sampleIndexInt in draft)) {
+            draft[sampleIndexInt] = {};
+          }
+          draft[sampleIndexInt][modalSlot.name] = result;
         } else {
-          delete draft[parseInt(sampleIndex)][modalSlot.name];
+          // If the sample previously passed validation, its index won't be
+          // in `draft`. Since it's still passing after this partial
+          // validation, just move on.
+          if (!(sampleIndexInt in draft)) {
+            return;
+          }
+          delete draft[sampleIndexInt][modalSlot.name];
         }
       }),
     );

--- a/src/pages/SamplePage/SamplePage.tsx
+++ b/src/pages/SamplePage/SamplePage.tsx
@@ -1,12 +1,19 @@
 import React, { useEffect, useMemo } from "react";
 import {
   IonBackButton,
+  IonButton,
   IonButtons,
   IonContent,
   IonHeader,
+  IonIcon,
+  IonItem,
+  IonList,
   IonPage,
+  IonPopover,
   IonTitle,
   IonToolbar,
+  useIonAlert,
+  useIonRouter,
 } from "@ionic/react";
 import { useParams } from "react-router";
 import { paths } from "../../Router";
@@ -18,6 +25,7 @@ import { SlotDefinition } from "../../linkml-metamodel";
 import SampleSlotEditModal from "../../components/SampleSlotEditModal/SampleSlotEditModal";
 import { produce } from "immer";
 import Validator, { ValidationResults } from "../../Validator";
+import { ellipsisHorizontal, ellipsisVertical } from "ionicons/icons";
 
 interface SamplePageParams {
   submissionId: string;
@@ -26,13 +34,16 @@ interface SamplePageParams {
 
 const SamplePage: React.FC = () => {
   const schema = useSubmissionSchema();
+  const router = useIonRouter();
+  const [presentAlert] = useIonAlert();
   const [modalSlot, setModalSlot] = React.useState<SlotDefinition | null>(null);
   const [validationResults, setValidationResults] =
     React.useState<ValidationResults>();
   const { submissionId, sampleIndex } = useParams<SamplePageParams>();
+  const sampleIndexInt = parseInt(sampleIndex);
   const { query: submission, updateMutation } = useSubmission(submissionId);
   const sample = useMemo(
-    () => getSubmissionSample(submission.data, parseInt(sampleIndex)),
+    () => getSubmissionSample(submission.data, sampleIndexInt),
     [submission.data, sampleIndex],
   );
 
@@ -56,7 +67,7 @@ const SamplePage: React.FC = () => {
       return;
     }
     const updatedSubmission = produce(submission.data, (draft) => {
-      const sample = getSubmissionSample(draft, parseInt(sampleIndex));
+      const sample = getSubmissionSample(draft, sampleIndexInt);
       if (sample) {
         if (value != null) {
           sample[modalSlot.name] = value;
@@ -99,6 +110,32 @@ const SamplePage: React.FC = () => {
     setValidationResults(results);
   }, [validator, submission.data]);
 
+  const handleDeleteInitiate = () => {
+    presentAlert({
+      header: "Delete Sample",
+      message: "Are you sure you want to delete this sample?",
+      buttons: [
+        "Cancel",
+        {
+          text: "Delete",
+          handler: () => {
+            if (!submission.data) {
+              return;
+            }
+            const updatedSubmission = produce(submission.data, (draft) => {
+              const samples = getSubmissionSamples(draft);
+              samples.splice(sampleIndexInt, 1);
+            });
+            updateMutation.mutate(updatedSubmission, {
+              onSuccess: () =>
+                router.push(paths.studyView(submissionId), "back"),
+            });
+          },
+        },
+      ],
+    });
+  };
+
   return (
     <IonPage>
       <IonHeader>
@@ -109,9 +146,31 @@ const SamplePage: React.FC = () => {
             ></IonBackButton>
           </IonButtons>
           <IonTitle>Sample</IonTitle>
+          <IonButtons slot="primary">
+            <IonButton id="ellipsis-menu-trigger">
+              <IonIcon
+                slot="icon-only"
+                ios={ellipsisHorizontal}
+                md={ellipsisVertical}
+              ></IonIcon>
+            </IonButton>
+          </IonButtons>
         </IonToolbar>
       </IonHeader>
       <IonContent>
+        <IonPopover
+          trigger="ellipsis-menu-trigger"
+          triggerAction="click"
+          dismissOnSelect
+        >
+          <IonContent>
+            <IonList lines="none">
+              <IonItem button detail={false} onClick={handleDeleteInitiate}>
+                Delete Sample
+              </IonItem>
+            </IonList>
+          </IonContent>
+        </IonPopover>
         {schema.data && (
           <>
             <SampleView
@@ -119,7 +178,7 @@ const SamplePage: React.FC = () => {
               sample={sample}
               schema={schema.data}
               schemaClass={schemaClassName}
-              validationResults={validationResults?.[parseInt(sampleIndex)]}
+              validationResults={validationResults?.[sampleIndexInt]}
             />
             <SampleSlotEditModal
               defaultValue={modalSlot && sample?.[modalSlot.name]}
@@ -131,7 +190,7 @@ const SamplePage: React.FC = () => {
               slot={modalSlot}
               validationResult={
                 modalSlot
-                  ? validationResults?.[parseInt(sampleIndex)]?.[modalSlot.name]
+                  ? validationResults?.[sampleIndexInt]?.[modalSlot.name]
                   : undefined
               }
             />

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,9 +20,7 @@ export function getSubmissionSample(
   if (!submission || index === undefined) {
     return undefined;
   }
-  return getSubmissionSamples(submission).find(
-    (sample) => sample._index === index,
-  );
+  return getSubmissionSamples(submission)[index];
 }
 
 function compareByRank(a: { rank?: number }, b: { rank?: number }): number {


### PR DESCRIPTION
Fixes #67 

Primarily this PR is about adding the ability to delete samples. This is implemented in `src/pages/SamplePage/SamplePage.tsx` similar to the way the delete study functionality works. However, in testing that functionality, I uncovered two bugs that I'm also addressing here.

First, I realized it was a mistake on my part to inject the `_index` field at the API layer. The only place it is really needed is in the `SampleList` component in order to keep sample indexes straight while filtering them. The downside of injecting the `_index` field way upstream in the API access methods is that it becomes part of the data that is sent back to the server when updating a sample. This, in an of itself, is not desirable since `_index` is a UI-only concern. But it also caused some confusion when looking up samples by `_index` to delete (which isn't even necessary -- `_index` is only necessary when filtering! but that's how I found this issue). So the fix here is to only inject those `_index` values at the layer it's needed: the `SampleList` component. 

Second, in testing I found a few validation-related bugs: 1) newly created samples weren't being validated and 2) issues when a previously valid sample gets partially re-validated as a field is updated. Those have also been fixed.