### PR TITLE
Add option to getSubmissionSamples to allow creating missing sampleData fields when necessary

### DIFF
--- a/src/components/StudyView/StudyView.tsx
+++ b/src/components/StudyView/StudyView.tsx
@@ -27,7 +27,9 @@ const StudyView: React.FC<StudyViewProps> = ({ submissionId }) => {
       return;
     }
     const updatedSubmission = produce(submission.data, (draft) => {
-      const samples = getSubmissionSamples(draft);
+      const samples = getSubmissionSamples(draft, {
+        createSampleDataFieldIfMissing: true,
+      });
       samples.push({});
     });
     updateMutation.mutate(updatedSubmission, {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,13 @@
 import { SubmissionMetadata, TEMPLATES } from "./api";
 import { SchemaDefinition, SlotDefinition } from "./linkml-metamodel";
 
-export function getSubmissionSamples(submission?: SubmissionMetadata) {
+export interface GetSubmissionSamplesOptions {
+  createSampleDataFieldIfMissing?: boolean;
+}
+export function getSubmissionSamples(
+  submission?: SubmissionMetadata,
+  options: GetSubmissionSamplesOptions = {},
+) {
   if (!submission) {
     return [];
   }
@@ -9,6 +15,12 @@ export function getSubmissionSamples(submission?: SubmissionMetadata) {
   const sampleDataField = TEMPLATES[environmentalPackageName]?.sampleDataSlot;
   if (!sampleDataField) {
     return [];
+  }
+  if (
+    !(sampleDataField in submission.metadata_submission.sampleData) &&
+    options.createSampleDataFieldIfMissing
+  ) {
+    submission.metadata_submission.sampleData[sampleDataField] = [];
   }
   return submission.metadata_submission.sampleData[sampleDataField] || [];
 }


### PR DESCRIPTION
Fixes #74 

When a new submission is created it looks (in part) like:

```js
{
  ...
  metadata_submission: {
    ...
    sampleData: { }
  }
}
```

The existing logic of `getSubmissionSamples` would look for a field like `soil_data` in the `sampleData` object and if it wasn't there (as in the above case) then it would return a new empty array. This works fine for cases where the `sampleData` needs to be _displayed_. However when the `sampleData` is being _modified_ we need to ensure that the (for example) `soil_data` field is present in `sampleData` and set it to an empty array if it wasn't previously there.

The fix here to add an `options` parameter to `getSubmissionSamples` with a `createSampleDataFieldIfMissing` field. We set that field to `true` when creating new samples. 