### PR TITLE
Implement "Guide" screen that contains familiar checklist

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -16,6 +16,7 @@ import TabNavigator from "./components/TabNavigator/TabNavigator";
 import PlaceholderPage from "./pages/PlaceholderPage";
 import StudyEditPage from "./pages/StudyEditPage/StudyEditPage";
 import SamplePage from "./pages/SamplePage/SamplePage";
+import GuidePage from "./pages/GuidePage/GuidePage";
 
 const IN = "/in";
 const STUDY = `${IN}/study`;
@@ -87,10 +88,7 @@ const Router: React.FC = () => {
 
             {/* GUIDE TAB ROUTES */}
             <AuthRoute exact path={paths.guide}>
-              <PlaceholderPage
-                title={"Guide"}
-                body={"Base route on Guide tab"}
-              />
+              <GuidePage />
             </AuthRoute>
 
             {/* SETTINGS TAB ROUTES */}

--- a/src/pages/GuidePage/GuidePage.tsx
+++ b/src/pages/GuidePage/GuidePage.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import {
+  IonBackButton,
+  IonButtons,
+  IonContent,
+  IonHeader,
+  IonPage,
+  IonTitle,
+} from "@ionic/react";
+import Checklist from "../../components/Checklist/Checklist";
+import ThemedToolbar from "../../components/ThemedToolbar/ThemedToolbar";
+
+const GuidePage: React.FC = () => {
+  return (
+    <IonPage>
+      <IonHeader>
+        <ThemedToolbar>
+          <IonButtons slot={"start"}>
+            <IonBackButton defaultHref={"/"}></IonBackButton>
+          </IonButtons>
+          <IonTitle>Guide</IonTitle>
+        </ThemedToolbar>
+      </IonHeader>
+      <IonContent>
+        <Checklist />
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default GuidePage;


### PR DESCRIPTION
In this PR branch, I replaced the "placeholder" "Guide" screen with one that shows the same checklist (i.e. uses the same component) as the one accessible from the "Welcome" page.

Here's a screenshot of the newly-implemented "Guide" screen:

<img width="365" alt="image" src="https://github.com/microbiomedata/nmdc-field-notes/assets/134325062/075e04ea-6126-40cd-9963-def3846e9521">
