### PR TITLE
Fix vertical alignment of version number on "Settings" screen (on Android/MD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ By default, Ionic will use the web browser's user agent to determine whether to 
 - http://localhost:5173/
 + http://localhost:5173/?ionic:mode=md
 ```
+
 > The `md` stands for [Material Design](https://material.google.com).
 
 ### Run linter

--- a/README.md
+++ b/README.md
@@ -74,14 +74,22 @@ You can visit the development server at:
 
 #### Switching styles between iOS and Android
 
-By default, Ionic will use the web browser's user agent to determine whether to style the web app like an iOS app or an Android app. For most web browser user agents, it will style it like an Android app. You can force a particular style by adding the `ionic:mode` [query parameter](https://ionicframework.com/docs/developing/tips#changing-mode) to the URL.
+By default, Ionic will use the web browser's user agent to determine whether to style the web app like an iOS app or an Android app. For most web browser user agents, it will style it like an Android app. You can force a particular style by adding the `ionic:mode` [query parameter](https://ionicframework.com/docs/developing/tips#changing-mode) to the URL, as shown below.
 
-For example, to force Ionic to style the web app like an _iOS_ app, you can modify the URL like this:
+##### Force iOS style
 
 ```diff
 - http://localhost:5173/
 + http://localhost:5173/?ionic:mode=ios
 ```
+
+##### Force Android style
+
+```diff
+- http://localhost:5173/
++ http://localhost:5173/?ionic:mode=md
+```
+> The `md` stands for [Material Design](https://material.google.com).
 
 ### Run linter
 

--- a/src/pages/SettingsPage/SettingsPage.tsx
+++ b/src/pages/SettingsPage/SettingsPage.tsx
@@ -29,7 +29,7 @@ const SettingsPage: React.FC = () => {
         <IonList inset={true}>
           <IonItem>
             <IonLabel>App version</IonLabel>
-            <IonNote color={"medium"}>{config.APP_VERSION}</IonNote>
+            <IonNote color={"medium"} slot={"end"}>{config.APP_VERSION}</IonNote>
           </IonItem>
         </IonList>
       </IonContent>

--- a/src/pages/SettingsPage/SettingsPage.tsx
+++ b/src/pages/SettingsPage/SettingsPage.tsx
@@ -29,7 +29,9 @@ const SettingsPage: React.FC = () => {
         <IonList inset={true}>
           <IonItem>
             <IonLabel>App version</IonLabel>
-            <IonNote color={"medium"} slot={"end"}>{config.APP_VERSION}</IonNote>
+            <IonNote color={"medium"} slot={"end"}>
+              {config.APP_VERSION}
+            </IonNote>
           </IonItem>
         </IonList>
       </IonContent>


### PR DESCRIPTION
In this branch, I fixed the vertical alignment of the version number on the "Settings" screen (on Android/MD devices). It was already correct on iOS devices.

Before:

<img width="460" alt="image" src="https://github.com/microbiomedata/nmdc-field-notes/assets/134325062/3a1f5091-4ec0-41a0-bf31-217ec61547ae">

After:

<img width="460" alt="image" src="https://github.com/microbiomedata/nmdc-field-notes/assets/134325062/02991051-5be9-458d-94d6-9dcceca51270">

I also updated `README.md` so that it explicitly lists the query string developers can use to force the styles to be Android/MD, in an attempt to facilitate testing with both styles in the future.