### PR TITLE
Fix scrolling issue in sample edit modal

### DIFF
--- a/src/components/SampleSlotEditModal/SampleSlotEditModal.module.css
+++ b/src/components/SampleSlotEditModal/SampleSlotEditModal.module.css
@@ -1,3 +1,21 @@
+ion-modal.sampleSlotEditModal {
+  /**
+   * This is the height of the modal when it is in the "expanded" state. The docs recommend this
+   * approach over having a max breakpoint < 1. See:
+   *   - https://ionicframework.com/docs/api/modal#custom-sheet-height
+   *   - https://github.com/ionic-team/ionic-framework/issues/24583
+   */
+  --height: 80vh;
+}
+
+ion-modal.sampleSlotEditModal::part(content) {
+  /**
+   * This makes the sheet modal handle look a little more natural when content scrolls under it.
+   * The value is derived from the handle height and top offset.
+   */
+  padding-top: 15px;
+}
+
 .inputAndClearContainer {
   border-color: var(--ion-color-primary);
   border-width: 2px;

--- a/src/components/SampleSlotEditModal/SampleSlotEditModal.tsx
+++ b/src/components/SampleSlotEditModal/SampleSlotEditModal.tsx
@@ -10,6 +10,7 @@ import {
   IonCol,
   IonContent,
   IonGrid,
+  IonHeader,
   IonIcon,
   IonItem,
   IonLabel,
@@ -19,6 +20,8 @@ import {
   IonSelectOption,
   IonText,
   IonTextarea,
+  IonTitle,
+  IonToolbar,
 } from "@ionic/react";
 import SchemaSlotHelp from "../SchemaSlotHelp/SchemaSlotHelp";
 import { closeCircle, warningOutline } from "ionicons/icons";
@@ -197,14 +200,15 @@ const SampleSlotEditModal: React.FC<SampleSlotEditModalProps> = ({
 
   return (
     <IonModal
-      breakpoints={[0, 0.8]}
-      initialBreakpoint={0.8}
+      className={styles.sampleSlotEditModal}
+      breakpoints={[0, 1]}
+      initialBreakpoint={1}
       isOpen={slot !== null}
       onIonModalDidDismiss={onCancel}
     >
       {slot && (
         <IonContent className="ion-padding">
-          <h2>{slot.title || slot.name}</h2>
+          <h2 className={styles.slotName}>{slot.title || slot.name}</h2>
           <div className={styles.inputAndClearContainer}>
             <div className={styles.inputWrapper}>
               {selectState.isSelectable ? (

--- a/src/components/SampleSlotEditModal/SampleSlotEditModal.tsx
+++ b/src/components/SampleSlotEditModal/SampleSlotEditModal.tsx
@@ -208,7 +208,7 @@ const SampleSlotEditModal: React.FC<SampleSlotEditModalProps> = ({
     >
       {slot && (
         <IonContent className="ion-padding">
-          <h2 className={styles.slotName}>{slot.title || slot.name}</h2>
+          <h2>{slot.title || slot.name}</h2>
           <div className={styles.inputAndClearContainer}>
             <div className={styles.inputWrapper}>
               {selectState.isSelectable ? (


### PR DESCRIPTION
Fixes #84 

These changes allow the sample edit modal contents to be scrolled. This means that on a small-ish device, when the contents of the modal are long (e.g. in when editing the "broad-scale environmental context" slot), you will be able to scroll down to see the save button. 

Relevant technical links in code comments.
