### PR TITLE
Install `madge` NPM package and eliminate circular dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,9 +41,11 @@ jobs:
       - name: Install npm packages
         run: npm ci
       - name: Check formatting
-        run: npm run format:check
+        run: npm run check.format
       - name: Lint code
         run: npm run lint
+      - name: Check for circular imports
+        run: npm run check.imports
       - name: Run build
         run: npm run build
       - name: Run unit tests

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ npm run lint
 > That tells npm you want it to run the script named `lint`, defined in the `package.json` file.
 > At the time of this writing, that script runs `eslint src`.
 
-
 ### Run circular import check
 
 Identify circular imports using the [`madge`](https://github.com/pahen/madge) package.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ npm run lint
 > That tells npm you want it to run the script named `lint`, defined in the `package.json` file.
 > At the time of this writing, that script runs `eslint src`.
 
+
+### Run circular import check
+
+Identify circular imports using the [`madge`](https://github.com/pahen/madge) package.
+
+```shell
+npm run check.imports
+```
+
 ### Run automated tests
 
 #### Unit tests
@@ -155,10 +164,10 @@ You can use it like this:
 
 ```shell
 # Check whether any files are not formatted.
-npx run format:check
+npm run check.format
 
 # Format all files.
-npx run format
+npm run format
 ```
 
 The `.prettierignore` file tells Prettier which files we want it to

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "eslint-plugin-storybook": "^0.6.15",
         "eslint-plugin-testing-library": "^6.2.0",
         "jsdom": "^22.1.0",
+        "madge": "^7.0.0",
         "msw": "^2.1.5",
         "prettier": "3.2.1",
         "storybook": "^7.6.8",
@@ -2362,6 +2363,19 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@dependents/detective-less": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@dependents/detective-less/-/detective-less-4.1.0.tgz",
+      "integrity": "sha512-KrkT6qO5NxqNfy68sBl6CTSoJ4SNDIS5iQArkibhlbGU4LaDukZ3q2HIkh8aUKDio6o4itU4xDR7t82Y2eP1Bg==",
+      "dev": true,
+      "dependencies": {
+        "gonzales-pe": "^4.3.0",
+        "node-source-walk": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -7011,6 +7025,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "dev": true,
@@ -7022,6 +7042,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/app-module-path": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
+      "integrity": "sha512-gkco+qxENJV+8vFcDiiFhuoSvRXb2a/QPqpSoWhVz829VNJfOTnELbBmPmNKFxf3xdNnw4DWCkzkDaavcX/1YQ==",
+      "dev": true
     },
     "node_modules/app-root-dir": {
       "version": "1.0.2",
@@ -7275,6 +7301,15 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/ast-module-types": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-5.0.0.tgz",
+      "integrity": "sha512-JvqziE0Wc0rXQfma0HZC/aY7URXHFuZV84fJRtP8u+lhp0JYCNd5wJzVXP45t0PH0Mej3ynlzvdyITYIu0G4LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/ast-types": {
@@ -9357,6 +9392,33 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dependency-tree": {
+      "version": "10.0.9",
+      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-10.0.9.tgz",
+      "integrity": "sha512-dwc59FRIsht+HfnTVM0BCjJaEWxdq2YAvEDy4/Hn6CwS3CBWMtFnL3aZGAkQn3XCYxk/YcTDE4jX2Q7bFTwCjA==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.1",
+        "filing-cabinet": "^4.1.6",
+        "precinct": "^11.0.5",
+        "typescript": "^5.0.4"
+      },
+      "bin": {
+        "dependency-tree": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "license": "MIT",
@@ -9457,6 +9519,170 @@
       "bin": {
         "detect": "bin/detect-port.js",
         "detect-port": "bin/detect-port.js"
+      }
+    },
+    "node_modules/detective-amd": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-5.0.2.tgz",
+      "integrity": "sha512-XFd/VEQ76HSpym80zxM68ieB77unNuoMwopU2TFT/ErUk5n4KvUTwW4beafAVUugrjV48l4BmmR0rh2MglBaiA==",
+      "dev": true,
+      "dependencies": {
+        "ast-module-types": "^5.0.0",
+        "escodegen": "^2.0.0",
+        "get-amd-module-type": "^5.0.1",
+        "node-source-walk": "^6.0.1"
+      },
+      "bin": {
+        "detective-amd": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/detective-cjs": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-5.0.1.tgz",
+      "integrity": "sha512-6nTvAZtpomyz/2pmEmGX1sXNjaqgMplhQkskq2MLrar0ZAIkHMrDhLXkRiK2mvbu9wSWr0V5/IfiTrZqAQMrmQ==",
+      "dev": true,
+      "dependencies": {
+        "ast-module-types": "^5.0.0",
+        "node-source-walk": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/detective-es6": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-4.0.1.tgz",
+      "integrity": "sha512-k3Z5tB4LQ8UVHkuMrFOlvb3GgFWdJ9NqAa2YLUU/jTaWJIm+JJnEh4PsMc+6dfT223Y8ACKOaC0qcj7diIhBKw==",
+      "dev": true,
+      "dependencies": {
+        "node-source-walk": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/detective-postcss": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-6.1.3.tgz",
+      "integrity": "sha512-7BRVvE5pPEvk2ukUWNQ+H2XOq43xENWbH0LcdCE14mwgTBEAMoAx+Fc1rdp76SmyZ4Sp48HlV7VedUnP6GA1Tw==",
+      "dev": true,
+      "dependencies": {
+        "is-url": "^1.2.4",
+        "postcss": "^8.4.23",
+        "postcss-values-parser": "^6.0.2"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/detective-sass": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-5.0.3.tgz",
+      "integrity": "sha512-YsYT2WuA8YIafp2RVF5CEfGhhyIVdPzlwQgxSjK+TUm3JoHP+Tcorbk3SfG0cNZ7D7+cYWa0ZBcvOaR0O8+LlA==",
+      "dev": true,
+      "dependencies": {
+        "gonzales-pe": "^4.3.0",
+        "node-source-walk": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/detective-scss": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-4.0.3.tgz",
+      "integrity": "sha512-VYI6cHcD0fLokwqqPFFtDQhhSnlFWvU614J42eY6G0s8c+MBhi9QAWycLwIOGxlmD8I/XvGSOUV1kIDhJ70ZPg==",
+      "dev": true,
+      "dependencies": {
+        "gonzales-pe": "^4.3.0",
+        "node-source-walk": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/detective-stylus": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-4.0.0.tgz",
+      "integrity": "sha512-TfPotjhszKLgFBzBhTOxNHDsutIxx9GTWjrL5Wh7Qx/ydxKhwUrlSFeLIn+ZaHPF+h0siVBkAQSuy6CADyTxgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/detective-typescript": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-11.2.0.tgz",
+      "integrity": "sha512-ARFxjzizOhPqs1fYC/2NMC3N4jrQ6HvVflnXBTRqNEqJuXwyKLRr9CrJwkRcV/SnZt1sNXgsF6FPm0x57Tq0rw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "^5.62.0",
+        "ast-module-types": "^5.0.0",
+        "node-source-walk": "^6.0.2",
+        "typescript": "^5.4.4"
+      },
+      "engines": {
+        "node": "^14.14.0 || >=16.0.0"
+      }
+    },
+    "node_modules/detective-typescript/node_modules/@typescript-eslint/types": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/detective-typescript/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detective-typescript/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/devlop": {
@@ -9725,6 +9951,19 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.1.tgz",
+      "integrity": "sha512-4U5pNsuDl0EhuZpq46M5xPslstkviJuhrdobaRDBk2Jy2KO37FDAJl4lb2KlNabxT0m4MTK2UHNrsAcphE8nyw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/enquirer": {
@@ -10959,6 +11198,41 @@
         "node": ">=10"
       }
     },
+    "node_modules/filing-cabinet": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-4.2.0.tgz",
+      "integrity": "sha512-YZ21ryzRcyqxpyKggdYSoXx//d3sCJzM3lsYoaeg/FyXdADGJrUl+BW1KIglaVLJN5BBcMtWylkygY8zBp2MrQ==",
+      "dev": true,
+      "dependencies": {
+        "app-module-path": "^2.2.0",
+        "commander": "^10.0.1",
+        "enhanced-resolve": "^5.14.1",
+        "is-relative-path": "^1.0.2",
+        "module-definition": "^5.0.1",
+        "module-lookup-amd": "^8.0.5",
+        "resolve": "^1.22.3",
+        "resolve-dependency-path": "^3.0.2",
+        "sass-lookup": "^5.0.1",
+        "stylus-lookup": "^5.0.1",
+        "tsconfig-paths": "^4.2.0",
+        "typescript": "^5.0.4"
+      },
+      "bin": {
+        "filing-cabinet": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/filing-cabinet/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "dev": true,
@@ -11356,6 +11630,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-amd-module-type": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-5.0.1.tgz",
+      "integrity": "sha512-jb65zDeHyDjFR1loOVk0HQGM5WNwoGB8aLWy3LKCieMKol0/ProHkhO2X1JxojuN10vbz1qNn09MJ7tNp7qMzw==",
+      "dev": true,
+      "dependencies": {
+        "ast-module-types": "^5.0.0",
+        "node-source-walk": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "dev": true,
@@ -11405,6 +11692,12 @@
       "engines": {
         "node": ">=12.17"
       }
+    },
+    "node_modules/get-own-enumerable-property-symbols": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+      "dev": true
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
@@ -11835,6 +12128,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gonzales-pe": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
+      "integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "gonzales": "bin/gonzales.js"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/gopd": {
@@ -12818,6 +13126,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-relative-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-relative-path/-/is-relative-path-1.0.2.tgz",
+      "integrity": "sha512-i1h+y50g+0hRbBD+dbnInl3JlJ702aar58snAeX+MxBAPvzXGej7sYoPMhlnykabt0ZzCJNBEyzMlekuQZN7fA==",
+      "dev": true
+    },
     "node_modules/is-set": {
       "version": "2.0.3",
       "dev": true,
@@ -12916,6 +13239,24 @@
       "version": "0.1.0",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "dev": true
+    },
+    "node_modules/is-url-superb": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
+      "integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -13840,6 +14181,54 @@
       "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/madge": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/madge/-/madge-7.0.0.tgz",
+      "integrity": "sha512-x9eHkBWoCJ2B8yGesWf8LRucarkbH5P3lazqgvmxe4xn5U2Meyfu906iG9mBB1RnY/f4D+gtELWdiz1k6+jAZA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "commander": "^7.2.0",
+        "commondir": "^1.0.1",
+        "debug": "^4.3.4",
+        "dependency-tree": "^10.0.9",
+        "ora": "^5.4.1",
+        "pluralize": "^8.0.0",
+        "precinct": "^11.0.5",
+        "pretty-ms": "^7.0.1",
+        "rc": "^1.2.8",
+        "stream-to-array": "^2.3.0",
+        "ts-graphviz": "^1.8.1",
+        "walkdir": "^0.4.1"
+      },
+      "bin": {
+        "madge": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://www.paypal.me/pahen"
+      },
+      "peerDependencies": {
+        "typescript": "^3.9.5 || ^4.9.5 || ^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/madge/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/magic-string": {
@@ -14771,6 +15160,92 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/module-definition": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-5.0.1.tgz",
+      "integrity": "sha512-kvw3B4G19IXk+BOXnYq/D/VeO9qfHaapMeuS7w7sNUqmGaA6hywdFHMi+VWeR9wUScXM7XjoryTffCZ5B0/8IA==",
+      "dev": true,
+      "dependencies": {
+        "ast-module-types": "^5.0.0",
+        "node-source-walk": "^6.0.1"
+      },
+      "bin": {
+        "module-definition": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/module-lookup-amd": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-8.0.5.tgz",
+      "integrity": "sha512-vc3rYLjDo5Frjox8NZpiyLXsNWJ5BWshztc/5KSOMzpg9k5cHH652YsJ7VKKmtM4SvaxuE9RkrYGhiSjH3Ehow==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.1",
+        "glob": "^7.2.3",
+        "requirejs": "^2.3.6",
+        "requirejs-config-file": "^4.0.0"
+      },
+      "bin": {
+        "lookup-amd": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/module-lookup-amd/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/module-lookup-amd/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/module-lookup-amd/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/module-lookup-amd/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "license": "MIT"
@@ -15029,6 +15504,18 @@
       "version": "2.0.14",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-source-walk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-6.0.2.tgz",
+      "integrity": "sha512-jn9vOIK/nfqoFCcpK89/VCVaLg1IHE6UVfDOzvqmANaJ/rWCTEdH8RZ1V278nv2jr36BJdyQXIAavBLXpzdlag==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.21.8"
+      },
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/nodemon": {
       "version": "2.0.22",
@@ -15653,6 +16140,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse5": {
       "version": "7.1.2",
       "dev": true,
@@ -15896,6 +16392,15 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/polished": {
       "version": "4.3.1",
       "dev": true,
@@ -15940,6 +16445,23 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-values-parser": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-6.0.2.tgz",
+      "integrity": "sha512-YLJpK0N1brcNJrs9WatuJFtHaV9q5aAOj+S4DI5S7jgHlRfm0PIbDCAFRYMQD5SHq7Fy6xsDhyutgS0QOAs0qw==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "is-url-superb": "^4.0.0",
+        "quote-unquote": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.9"
       }
     },
     "node_modules/prebuild-install": {
@@ -15996,6 +16518,41 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/precinct": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/precinct/-/precinct-11.0.5.tgz",
+      "integrity": "sha512-oHSWLC8cL/0znFhvln26D14KfCQFFn4KOLSw6hmLhd+LQ2SKt9Ljm89but76Pc7flM9Ty1TnXyrA2u16MfRV3w==",
+      "dev": true,
+      "dependencies": {
+        "@dependents/detective-less": "^4.1.0",
+        "commander": "^10.0.1",
+        "detective-amd": "^5.0.2",
+        "detective-cjs": "^5.0.1",
+        "detective-es6": "^4.0.1",
+        "detective-postcss": "^6.1.3",
+        "detective-sass": "^5.0.3",
+        "detective-scss": "^4.0.3",
+        "detective-stylus": "^4.0.0",
+        "detective-typescript": "^11.1.0",
+        "module-definition": "^5.0.1",
+        "node-source-walk": "^6.0.2"
+      },
+      "bin": {
+        "precinct": "bin/cli.js"
+      },
+      "engines": {
+        "node": "^14.14.0 || >=16.0.0"
+      }
+    },
+    "node_modules/precinct/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -16061,6 +16618,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
+      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
+      "dev": true,
+      "dependencies": {
+        "parse-ms": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/process": {
@@ -16394,6 +16966,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/quote-unquote": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/quote-unquote/-/quote-unquote-1.0.0.tgz",
+      "integrity": "sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==",
+      "dev": true
     },
     "node_modules/ramda": {
       "version": "0.29.0",
@@ -17509,6 +18087,32 @@
         "node": ">=0.10.5"
       }
     },
+    "node_modules/requirejs": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
+      "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==",
+      "dev": true,
+      "bin": {
+        "r_js": "bin/r.js",
+        "r.js": "bin/r.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/requirejs-config-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/requirejs-config-file/-/requirejs-config-file-4.0.0.tgz",
+      "integrity": "sha512-jnIre8cbWOyvr8a5F2KuqBnY+SDA4NXr/hzEZJG79Mxm2WiFQz2dzhC8ibtPJS7zkmBEl1mxSwp5HhC1W4qpxw==",
+      "dev": true,
+      "dependencies": {
+        "esprima": "^4.0.0",
+        "stringify-object": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "dev": true,
@@ -17528,6 +18132,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-dependency-path": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/resolve-dependency-path/-/resolve-dependency-path-3.0.2.tgz",
+      "integrity": "sha512-Tz7zfjhLfsvR39ADOSk9us4421J/1ztVBo4rWUkF38hgHK5m0OCZ3NxFVpqHRkjctnwVa15igEUHFJp8MCS7vA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/resolve-from": {
@@ -17730,6 +18343,30 @@
       "version": "2.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sass-lookup": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-5.0.1.tgz",
+      "integrity": "sha512-t0X5PaizPc2H4+rCwszAqHZRtr4bugo4pgiCvrBFvIX0XFxnr29g77LJcpyj9A0DcKf7gXMLcgvRjsonYI6x4g==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.1"
+      },
+      "bin": {
+        "sass-lookup": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/sass-lookup/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/sax": {
       "version": "1.1.4",
@@ -18274,6 +18911,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stream-to-array": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
+      "integrity": "sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.1.0"
+      }
+    },
     "node_modules/streamx": {
       "version": "2.16.1",
       "dev": true,
@@ -18409,6 +19055,29 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "dev": true,
+      "dependencies": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/stringify-object/node_modules/is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "dev": true,
@@ -18502,6 +19171,30 @@
         "inline-style-parser": "0.2.3"
       }
     },
+    "node_modules/stylus-lookup": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-5.0.1.tgz",
+      "integrity": "sha512-tLtJEd5AGvnVy4f9UHQMw4bkJJtaAcmo54N+ovQBjDY3DuWyK9Eltxzr5+KG0q4ew6v2EHyuWWNnHeiw/Eo7rQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.1"
+      },
+      "bin": {
+        "stylus-lookup": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/stylus-lookup/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "dev": true,
@@ -18538,6 +19231,15 @@
       "version": "6.15.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tar": {
       "version": "6.2.1",
@@ -18985,6 +19687,19 @@
         "node": ">=6.10"
       }
     },
+    "node_modules/ts-graphviz": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/ts-graphviz/-/ts-graphviz-1.8.2.tgz",
+      "integrity": "sha512-5YhbFoHmjxa7pgQLkB07MtGnGJ/yhvjmc9uhsnDBEICME6gkPf83SBwLDQqGDoCa3XzUMWLk1AU2Wn1u1naDtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ts-graphviz"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "dev": true,
@@ -19052,6 +19767,20 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tslib": {
@@ -19216,8 +19945,9 @@
     },
     "node_modules/typescript": {
       "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20008,6 +20738,15 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/walkdir": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
+      "integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/walker": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "format": "prettier . --write",
-    "format:check": "prettier . --check",
+    "check.format": "prettier . --check",
+    "check.imports": "madge --circular src/main.tsx",
     "sim.android": "npm run build && npx cap run android",
     "sim.ios": "npm run build && npx cap run ios",
     "preview": "vite preview",
@@ -78,6 +79,7 @@
     "eslint-plugin-storybook": "^0.6.15",
     "eslint-plugin-testing-library": "^6.2.0",
     "jsdom": "^22.1.0",
+    "madge": "^7.0.0",
     "msw": "^2.1.5",
     "prettier": "3.2.1",
     "storybook": "^7.6.8",
@@ -90,5 +92,9 @@
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.9.5"
   },
-  "description": "Mobile app for metadata collection on the go"
+  "description": "Mobile app for metadata collection on the go",
+  "madge": {
+    "tsConfig": "tsconfig.json",
+    "fileExtensions": ["ts", "tsx", "js", "jsx"]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -95,6 +95,11 @@
   "description": "Mobile app for metadata collection on the go",
   "madge": {
     "tsConfig": "tsconfig.json",
-    "fileExtensions": ["ts", "tsx", "js", "jsx"]
+    "fileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx"
+    ]
   }
 }

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -19,26 +19,7 @@ import SamplePage from "./pages/SamplePage/SamplePage";
 import GuidePage from "./pages/GuidePage/GuidePage";
 import SettingsPage from "./pages/SettingsPage/SettingsPage";
 import AppUrlListener from "./components/AppUrlListener/AppUrlListener";
-
-const IN = "/in";
-const STUDY = `${IN}/study`;
-export const paths = {
-  root: "/",
-  home: STUDY,
-  checklist: "/checklist",
-  tour: "/tour",
-  welcome: "/welcome",
-  login: "/login",
-  token: "/token",
-  logout: "/logout",
-  studyCreate: `${STUDY}/create`,
-  studyView: (submissionId: string) => `${STUDY}/${submissionId}`,
-  studyEdit: (submissionId: string) => `${STUDY}/${submissionId}/edit`,
-  sample: (submissionId: string, sampleIndex: string | number) =>
-    `${STUDY}/${submissionId}/sample/${sampleIndex}`,
-  guide: `${IN}/guide`,
-  settings: `${IN}/settings`,
-};
+import paths, { IN } from "./paths";
 
 const Router: React.FC = () => {
   const { apiToken } = useStore();

--- a/src/components/AuthRoute/AuthRoute.tsx
+++ b/src/components/AuthRoute/AuthRoute.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Redirect, Route, RouteProps } from "react-router-dom";
 import { useStore } from "../../Store";
-import { paths } from "../../Router";
+import paths from "../../paths";
 
 const AuthRoute: React.FC<RouteProps> = ({ children, ...rest }) => {
   const { apiToken } = useStore();

--- a/src/components/SampleList/SampleList.tsx
+++ b/src/components/SampleList/SampleList.tsx
@@ -14,7 +14,7 @@ import {
   IonSearchbar,
   SearchbarInputEventDetail,
 } from "@ionic/react";
-import { paths } from "../../Router";
+import paths from "../../paths";
 import { search as searchIcon } from "ionicons/icons";
 import NoneOr from "../NoneOr/NoneOr";
 import { IndexedSampleData, SubmissionMetadata } from "../../api";

--- a/src/components/StudyList/StudyList.tsx
+++ b/src/components/StudyList/StudyList.tsx
@@ -13,7 +13,7 @@ import {
 import { SubmissionMetadata } from "../../api";
 import Pluralize from "../Pluralize/Pluralize";
 import { getSubmissionSamples } from "../../utils";
-import { paths } from "../../Router";
+import paths from "../../paths";
 import NoneOr from "../NoneOr/NoneOr";
 
 const StudyList: React.FC = () => {

--- a/src/components/StudyView/StudyView.tsx
+++ b/src/components/StudyView/StudyView.tsx
@@ -12,7 +12,7 @@ import NoneOr from "../NoneOr/NoneOr";
 import SampleList from "../SampleList/SampleList";
 import { getSubmissionSamples } from "../../utils";
 import { produce } from "immer";
-import { paths } from "../../Router";
+import paths from "../../paths";
 
 interface StudyViewProps {
   submissionId: string;

--- a/src/components/TabNavigator/TabNavigator.tsx
+++ b/src/components/TabNavigator/TabNavigator.tsx
@@ -12,7 +12,7 @@ import {
   map as guideIcon,
   settings as settingsIcon,
 } from "ionicons/icons";
-import { paths } from "../../Router";
+import paths from "../../paths";
 
 interface Props extends PropsWithChildren {}
 

--- a/src/pages/LogoutPage/LogoutPage.tsx
+++ b/src/pages/LogoutPage/LogoutPage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useStore } from "../../Store";
 import { useHistory } from "react-router-dom";
-import { paths } from "../../Router";
+import paths from "../../paths";
 import { IonPage, useIonViewWillEnter } from "@ionic/react";
 
 const LogoutPage: React.FC = () => {

--- a/src/pages/SamplePage/SamplePage.tsx
+++ b/src/pages/SamplePage/SamplePage.tsx
@@ -15,7 +15,7 @@ import {
   useIonRouter,
 } from "@ionic/react";
 import { useParams } from "react-router";
-import { paths } from "../../Router";
+import paths from "../../paths";
 import { useSubmission, useSubmissionSchema } from "../../queries";
 import { getSubmissionSample, getSubmissionSamples } from "../../utils";
 import { SampleData, SampleDataValue, TEMPLATES } from "../../api";

--- a/src/pages/StudyCreatePage/StudyCreatePage.tsx
+++ b/src/pages/StudyCreatePage/StudyCreatePage.tsx
@@ -12,7 +12,7 @@ import {
 import StudyForm from "../../components/StudyForm/StudyForm";
 import { useSubmissionCreate } from "../../queries";
 import { SubmissionMetadataCreate } from "../../api";
-import { paths } from "../../Router";
+import paths from "../../paths";
 import { initSubmission } from "../../data";
 import { checkmark } from "ionicons/icons";
 import ThemedToolbar from "../../components/ThemedToolbar/ThemedToolbar";

--- a/src/pages/StudyEditPage/StudyEditPage.tsx
+++ b/src/pages/StudyEditPage/StudyEditPage.tsx
@@ -17,7 +17,7 @@ import {
   useIonToast,
 } from "@ionic/react";
 import { useParams } from "react-router";
-import { paths } from "../../Router";
+import paths from "../../paths";
 import StudyForm from "../../components/StudyForm/StudyForm";
 import { useSubmission } from "../../queries";
 import { SubmissionMetadata, SubmissionMetadataCreate } from "../../api";

--- a/src/pages/StudyViewPage/StudyViewPage.tsx
+++ b/src/pages/StudyViewPage/StudyViewPage.tsx
@@ -10,7 +10,7 @@ import {
   IonTitle,
 } from "@ionic/react";
 import StudyView from "../../components/StudyView/StudyView";
-import { paths } from "../../Router";
+import paths from "../../paths";
 import ThemedToolbar from "../../components/ThemedToolbar/ThemedToolbar";
 
 interface StudyViewPageParams {

--- a/src/pages/TokenPage/TokenPage.tsx
+++ b/src/pages/TokenPage/TokenPage.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useHistory, useLocation } from "react-router-dom";
 import { useStore } from "../../Store";
-import { paths } from "../../Router";
+import paths from "../../paths";
 import { IonPage, useIonViewWillEnter } from "@ionic/react";
 
 const TokenPage: React.FC = () => {

--- a/src/pages/WelcomePage/WelcomePage.tsx
+++ b/src/pages/WelcomePage/WelcomePage.tsx
@@ -15,7 +15,7 @@ import {
 } from "@ionic/react";
 import { logIn } from "ionicons/icons";
 import Logo from "../../components/Logo/Logo";
-import { paths } from "../../Router";
+import paths from "../../paths";
 import classes from "./WelcomePage.module.css";
 import { Browser } from "@capacitor/browser";
 import config from "../../config";

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,23 @@
+const IN = "/in";
+const STUDY = `${IN}/study`;
+
+const paths = {
+  root: "/",
+  home: STUDY,
+  checklist: "/checklist",
+  tour: "/tour",
+  welcome: "/welcome",
+  login: "/login",
+  token: "/token",
+  logout: "/logout",
+  studyCreate: `${STUDY}/create`,
+  studyView: (submissionId: string) => `${STUDY}/${submissionId}`,
+  studyEdit: (submissionId: string) => `${STUDY}/${submissionId}/edit`,
+  sample: (submissionId: string, sampleIndex: string | number) =>
+    `${STUDY}/${submissionId}/sample/${sampleIndex}`,
+  guide: `${IN}/guide`,
+  settings: `${IN}/settings`,
+};
+
+export default paths;
+export { IN, STUDY };


### PR DESCRIPTION
Fixes #115 

### Summary

These changes add a dependency on the [`madge`](https://github.com/pahen/madge) package and connect it to a new `check.imports` script in `package.json`. The script is now called in the tests workflow to ensure we don't introduce new circular dependencies. In #115 I talked about using [`dpdm`](https://github.com/acrazing/dpdm), but I realized after making the issues that `madge` seems to be more popular and has more people working on it. 

As far as fixing the existing circular imports, all of them looked something like this:

```mermaid
flowchart LR
    A(Router.tsx)
    A --> B(various pages & components)
    B --> A
```

Where the various pages & components were importing `Router.tsx` to get the `paths` object.

So the fix is to move the `paths` object to a separate module and you end up with:

```mermaid
flowchart TD
    A(paths.ts)
    B(Router.tsx) --> A
    C(various pages & components) --> A
```