### PR TITLE
Shorten iOS app icon text to "Field Notes" to avoid ellipses

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>NMDC Field Notes</string>
+	<string>Field Notes</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
In this branch, I configured the iOS app so that the text below the icon on the iOS home screen  says "Field Notes" (the app icon already says "nmdc" on it) instead of "NMDCFieldNot...".

iOS seems to me to impose a 15-character limit on this string. Optionally, see the comments in #124 for details.

Before:

![image](https://github.com/microbiomedata/nmdc-field-notes/assets/134325062/058ad7c7-ae28-4fbc-b5d7-865bbf198e57)

After:

![image](https://github.com/microbiomedata/nmdc-field-notes/assets/134325062/77edc43f-5979-4eda-84c7-08c666a83e83)
