### PR TITLE
Allow user to populate Study PI Name and ORCID iD with user's own info

### DIFF
--- a/src/components/StudyForm/StudyForm.tsx
+++ b/src/components/StudyForm/StudyForm.tsx
@@ -133,7 +133,7 @@ const StudyForm: React.FC<StudyFormProps> = ({ submission, onSave }) => {
                   slot={"end"}
                   title={"Use my name"}
                   aria-label={"Use my name"}
-                  onClick={() => field.onChange(loggedInUser.name)}
+                  onClick={() => setValue(field.name, loggedInUser.name)}
                   disabled={field.value === loggedInUser.name}
                 >
                   <IonIcon

--- a/src/components/StudyForm/StudyForm.tsx
+++ b/src/components/StudyForm/StudyForm.tsx
@@ -134,6 +134,7 @@ const StudyForm: React.FC<StudyFormProps> = ({ submission, onSave }) => {
                   title={"Use my name"}
                   aria-label={"Use my name"}
                   onClick={() => field.onChange(loggedInUser.name)}
+                  disabled={field.value === loggedInUser.name}
                 >
                   <IonIcon
                     slot={"icon-only"}
@@ -198,6 +199,7 @@ const StudyForm: React.FC<StudyFormProps> = ({ submission, onSave }) => {
                   title={"Use my ORCID iD"}
                   aria-label={"Use my ORCID iD"}
                   onClick={() => field.onChange(loggedInUser.orcid)}
+                  disabled={field.value === loggedInUser.orcid}
                 >
                   <IonIcon
                     slot={"icon-only"}

--- a/src/components/StudyForm/StudyForm.tsx
+++ b/src/components/StudyForm/StudyForm.tsx
@@ -133,11 +133,7 @@ const StudyForm: React.FC<StudyFormProps> = ({ submission, onSave }) => {
                   slot={"end"}
                   title={"Use my name"}
                   aria-label={"Use my name"}
-                  onClick={() => {
-                    // TODO: Populate the field with the logged-in user's name.
-                    const { name } = loggedInUser;
-                    alert(`TODO: Populate field with ${name}`);
-                  }}
+                  onClick={() => field.onChange(loggedInUser.name)}
                 >
                   <IonIcon
                     slot={"icon-only"}
@@ -201,11 +197,7 @@ const StudyForm: React.FC<StudyFormProps> = ({ submission, onSave }) => {
                   slot={"end"}
                   title={"Use my ORCID iD"}
                   aria-label={"Use my ORCID iD"}
-                  onClick={() => {
-                    // TODO: Populate the field with the logged-in user's ORCID iD.
-                    const { orcid } = loggedInUser;
-                    alert(`TODO: Populate field with ${orcid}`);
-                  }}
+                  onClick={() => field.onChange(loggedInUser.orcid)}
                 >
                   <IonIcon
                     slot={"icon-only"}

--- a/src/components/StudyForm/StudyForm.tsx
+++ b/src/components/StudyForm/StudyForm.tsx
@@ -198,7 +198,7 @@ const StudyForm: React.FC<StudyFormProps> = ({ submission, onSave }) => {
                   slot={"end"}
                   title={"Use my ORCID iD"}
                   aria-label={"Use my ORCID iD"}
-                  onClick={() => field.onChange(loggedInUser.orcid)}
+                  onClick={() => setValue(field.name, loggedInUser.orcid)}
                   disabled={field.value === loggedInUser.orcid}
                 >
                   <IonIcon

--- a/src/components/StudyForm/StudyForm.tsx
+++ b/src/components/StudyForm/StudyForm.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {
   IonButton,
+  IonIcon,
   IonInput,
   IonSelect,
   IonSelectOption,
@@ -11,6 +12,8 @@ import RequiredMark from "../RequiredMark/RequiredMark";
 import SectionHeader from "../SectionHeader/SectionHeader";
 import { SubmissionMetadataCreate, TEMPLATES } from "../../api";
 import { Controller, useForm } from "react-hook-form";
+import { useStore } from "../../Store";
+import { colorWand as autoFill } from "ionicons/icons";
 
 import styles from "./StudyForm.module.css";
 
@@ -34,6 +37,8 @@ const EMAIL_REGEX =
   /^(?!\.)(?!.*\.\.)([A-Z0-9_+-.]*)[A-Z0-9_+-]@([A-Z0-9][A-Z0-9-]*\.)+[A-Z]{2,}$/i;
 
 const StudyForm: React.FC<StudyFormProps> = ({ submission, onSave }) => {
+  const { loggedInUser } = useStore();
+
   const { handleSubmit, control, formState, setValue } =
     useForm<SubmissionMetadataCreate>({
       defaultValues: submission,
@@ -120,7 +125,29 @@ const StudyForm: React.FC<StudyFormProps> = ({ submission, onSave }) => {
               onIonBlur={field.onBlur}
               onIonInput={field.onChange}
               {...field}
-            />
+            >
+              {/* If the user is logged in, show a button they can press to use their name. */}
+              {loggedInUser !== null ? (
+                <IonButton
+                  fill={"clear"}
+                  slot={"end"}
+                  title={"Use my name"}
+                  aria-label={"Use my name"}
+                  onClick={() => {
+                    // TODO: Populate the field with the logged-in user's name.
+                    const { name } = loggedInUser;
+                    alert(`TODO: Populate field with ${name}`);
+                  }}
+                >
+                  <IonIcon
+                    slot={"icon-only"}
+                    icon={autoFill}
+                    color={"primary"}
+                    aria-hidden={"true"}
+                  />
+                </IonButton>
+              ) : null}
+            </IonInput>
           )}
         />
 
@@ -166,7 +193,29 @@ const StudyForm: React.FC<StudyFormProps> = ({ submission, onSave }) => {
               onIonBlur={field.onBlur}
               onIonInput={field.onChange}
               {...field}
-            />
+            >
+              {/* If the user is logged in, show a button they can press to use their ORCID iD. */}
+              {loggedInUser !== null ? (
+                <IonButton
+                  fill={"clear"}
+                  slot={"end"}
+                  title={"Use my ORCID iD"}
+                  aria-label={"Use my ORCID iD"}
+                  onClick={() => {
+                    // TODO: Populate the field with the logged-in user's ORCID iD.
+                    const { orcid } = loggedInUser;
+                    alert(`TODO: Populate field with ${orcid}`);
+                  }}
+                >
+                  <IonIcon
+                    slot={"icon-only"}
+                    icon={autoFill}
+                    color={"primary"}
+                    aria-hidden={"true"}
+                  />
+                </IonButton>
+              ) : null}
+            </IonInput>
           )}
         />
       </div>


### PR DESCRIPTION
In this branch, I added buttons on the right sides of two text inputs on the "Create Study" screen:
- Principal Investigator > Name
- Principal Investigator > ORCID iD

The buttons are only rendered when the user is logged in (so, if we end up allowing logged-out users to snoop around the UI, these buttons will not appear to them).

When the user clicks a button, the app will update the field so it contains the associated value from the user's own ORCID account. For example, if the user clicks the button on the "Name" field, the app will update the "Name" field so it contains the user's name.

When the field already contains the value that clicking the button would cause the field to have, the button is disabled.

Here's a brief screencast of the buttons in action (with personal information blurred here):

https://github.com/user-attachments/assets/d118223a-5360-4064-8e0c-683fc750e02a

Here are some things I think reviewers may request changes about:
1. Which icon I used (currently a wand icon)
2. Which color I used (currently the primary color from the theme)
3. The tooltip text that appears when the user hovers over the buttons (currently "Use my name" and "Use my ORCID iD")