### PR TITLE
Set source_client to field_notes when generating new submission

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -169,6 +169,7 @@ export interface User {
 
 export interface SubmissionMetadataCreate {
   metadata_submission: MetadataSubmission;
+  source_client: "submission_portal" | "field_notes" | null;
 }
 
 export interface SubmissionMetadata extends SubmissionMetadataCreate {

--- a/src/data.ts
+++ b/src/data.ts
@@ -76,4 +76,5 @@ export const initMetadataSubmission = (): MetadataSubmission => ({
 
 export const initSubmission = (): SubmissionMetadataCreate => ({
   metadata_submission: initMetadataSubmission(),
+  source_client: "field_notes",
 });

--- a/src/mocks/fixtures.ts
+++ b/src/mocks/fixtures.ts
@@ -40,6 +40,7 @@ export function generateSubmission(
       },
     },
     locked_by: null,
+    source_client: "field_notes",
   };
 }
 
@@ -115,6 +116,7 @@ export const submissions: SubmissionMetadata[] = [
     },
     lock_updated: "2024-01-01T00:00:00.000000",
     locked_by: null,
+    source_client: "submission_portal",
   },
   {
     metadata_submission: {
@@ -187,5 +189,6 @@ export const submissions: SubmissionMetadata[] = [
     },
     lock_updated: "2024-01-02T00:00:00.000000",
     locked_by: null,
+    source_client: "field_notes",
   },
 ];


### PR DESCRIPTION
Fixes #128 

This is a follow-on to https://github.com/microbiomedata/nmdc-server/pull/1300.

When a new submission is generated by the Field Notes app (`src/data.ts`), set the `source_client` field to `field_notes`. 

I made one of the mock submissions used in tests (`src/mocks/fixtures.ts`) have a `source_client` of `submission_portal` just to ensure that we don't do anything with the `source_client` field that implicitly assumes a value of `field_notes` coming _from_ the backend.
