### PR TITLE
Replace Apple Developer "ENT" Team ID with non-"ENT" Team ID

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -350,7 +350,7 @@
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 4L4Y2A43SA;
+				DEVELOPMENT_TEAM = 6G3V3EPHUC;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -372,7 +372,7 @@
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 4L4Y2A43SA;
+				DEVELOPMENT_TEAM = 6G3V3EPHUC;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -3,7 +3,7 @@
     "apps": [],
     "details": [
       {
-        "appID": "4L4Y2A43SA.org.microbiomedata.fieldnotes",
+        "appID": "6G3V3EPHUC.org.microbiomedata.fieldnotes",
         "paths": ["*"]
       }
     ]


### PR DESCRIPTION
Today, I deleted the NMDC Field Notes app identifier from the "ENT" Apple Developer account and created an NMDC Field Notes app identifier in the non-"ENT" Apple Developer account. The reason I first deleted it from the "ENT" account is so that I could use the same Bundle ID in the non-"ENT" account. The actions I took are documented in [this Issue comment](https://github.com/microbiomedata/nmdc-field-notes/issues/135#issuecomment-2249553410).

In this PR branch, I have updated all references to the Team ID so that, instead of referring to the Team corresponding to the "ENT" account (where our app identifier no longer exists), they refer to the Team corresponding to the non-"ENT" account (where our app identifier now exists).

Since I'll be out Friday, and given the specific changes involved, I may end up merging this in tonight—without review—so I can proceed to test (and, if needed, repair) deep link functionality sooner than I would otherwise be able to.