### PR TITLE
Allow cleartext HTTP requests only in non-production builds

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -6,9 +6,7 @@ const config: CapacitorConfig = {
   webDir: "dist",
   server: {
     androidScheme: "https",
-    // TODO: Don't use this in production!
-    // https://capacitorjs.com/docs/guides/environment-specific-configurations
-    cleartext: true,
+    cleartext: process.env.NODE_ENV !== "production",
   },
   plugins: {
     SplashScreen: {


### PR DESCRIPTION
Fixes #119 

Despite what this issue says, we didn't really need _true_ separate environments as outlined in https://capacitorjs.com/docs/guides/environment-specific-configurations. What's written there would be necessary for controlling things like app IDs or custom URI schemes by environment. For simply enabling/disabling cleartext HTTP requests we just needed to set the `cleartext` value based on `NODE_ENV`. 

I believe this only affects Android devices, so with `VITE_NMDC_SERVER_API_URL=http://127.0.0.1:8000` (with a local `nmdc-server` instance running) the app should behave normally when running:

```
npm run sim.android
```

However it should _not_ work when running:

```
NODE_ENV=production npm run sim.android
```

This is also a good reminder that we should explicitly set the `NODE_ENV` variable when we set up automated builds.