### PR TITLE
Fix permissions update

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -177,6 +177,8 @@ export interface SubmissionMetadataCreate extends SubmissionMetadataBase {
 }
 
 export interface SubmissionMetadataUpdate extends SubmissionMetadataBase {
+  id: string;
+  status?: string;
   // Map of ORCID iD to permission level
   permissions?: Record<string, string>;
 }

--- a/src/pages/StudyEditPage/StudyEditPage.tsx
+++ b/src/pages/StudyEditPage/StudyEditPage.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import {
   IonBackButton,
   IonButton,
@@ -50,6 +50,7 @@ const StudyEditPage: React.FC = () => {
     unlockMutation,
   } = useSubmission(submissionId);
   const { loggedInUser } = useStore();
+  const isDeleting = useRef(false);
 
   const loggedInUserCanEdit =
     loggedInUser &&
@@ -61,7 +62,7 @@ const StudyEditPage: React.FC = () => {
   });
 
   useIonViewDidLeave(() => {
-    if (loggedInUserCanEdit) {
+    if (loggedInUserCanEdit && !isDeleting.current) {
       unlockMutation.mutate(submissionId);
     }
   });
@@ -88,6 +89,7 @@ const StudyEditPage: React.FC = () => {
         {
           text: "Delete",
           handler: () => {
+            isDeleting.current = true;
             deleteMutation.mutate(submissionId, {
               onSuccess: () => router.push(paths.home, "back"),
             });

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -41,18 +41,22 @@ export const submissionKeys = {
 
 export function addDefaultMutationFns(queryClient: QueryClient) {
   queryClient.setMutationDefaults(submissionKeys.details(), {
-    mutationFn: async (updated: SubmissionMetadata) => {
+    mutationFn: async (updated: SubmissionMetadataUpdate) => {
       await queryClient.cancelQueries({
         queryKey: submissionKeys.detail(updated.id),
       });
       // Keep the permissions updated with the PI ORCID as an owner
-      const updatedWithPermissions: SubmissionMetadataUpdate = updated;
-      const { piOrcid } = updated.metadata_submission.studyForm;
-      if (piOrcid) {
-        updatedWithPermissions.permissions = {
-          [piOrcid]: "owner",
-        };
-      }
+      const updatedWithPermissions: SubmissionMetadataUpdate = produce(
+        updated,
+        (draft) => {
+          const { piOrcid } = draft.metadata_submission.studyForm;
+          if (piOrcid) {
+            draft.permissions = {
+              [piOrcid]: "owner",
+            };
+          }
+        },
+      );
       return nmdcServerClient.updateSubmission(
         updated.id,
         updatedWithPermissions,

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -75,7 +75,7 @@ export function addDefaultMutationFns(queryClient: QueryClient) {
       const { piOrcid } = created.metadata_submission.studyForm;
       if (piOrcid) {
         return nmdcServerClient.updateSubmission(created.id, {
-          metadata_submission: created.metadata_submission,
+          ...created,
           permissions: {
             [piOrcid]: "owner",
           },


### PR DESCRIPTION
This fixes a bug that Montana just reported to me that I had already fixed in a development branch for #42. That branch isn't quite ready for a PR, so I'm just cherry picking a couple of commits out of it.

The issue was introduced in #137, and the problem has to do with attempting to mutate an existing object in order to add the `permissions` field instead of using `produce` to perform the mutation.

Since this is a fairly egregious bug that prevents updating submissions we should produce and distribute new iOS and Android builds after this is merged in.