### PR TITLE
Document and further automate the release process

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,3 @@
+# This is intentionally set to the dev server for **internal** beta testing.
+# When we are ready for **external** beta testing, we should change this to the production server.
+VITE_NMDC_SERVER_API_URL=https://data-dev.microbiomedata.org

--- a/.env.staging
+++ b/.env.staging
@@ -1,2 +1,1 @@
 VITE_NMDC_SERVER_API_URL=https://data-dev.microbiomedata.org
-VITE_NMDC_SERVER_LOGIN_URL=https://data-dev.microbiomedata.org/login

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create Release
+        uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -237,27 +237,28 @@ Creating a release involves three steps: creating a new version tag and GitHub R
 #### Create Version Tag and GitHub Release
 
 1. Ensure you are on the main branch and have the latest changes.
-    ```shell
-    git checkout main && git pull
-    ```
+   ```shell
+   git checkout main && git pull
+   ```
 2. Run a test build. Ensure that this command completes successfully and leaves _no local changes_. If there are local changes, commit them separately before proceeding.
-    ```shell
-    ionic capacitor sync --prod
-    ```
+   ```shell
+   ionic capacitor sync --prod
+   ```
 3. Decide whether the new version will be a patch, minor, or major version. Then run the following to create a new version commit and tag.
 
-    > [!NOTE]
-    > During the beta testing period, use only minor or patch versions.
+   > [!NOTE]
+   > During the beta testing period, use only minor or patch versions.
 
-    ```shell
-    npm version patch  # (or "minor" or "major")
-    git push && git push --tags
-    ```
+   ```shell
+   npm version patch  # (or "minor" or "major")
+   git push && git push --tags
+   ```
+
 4. Check [GitHub Actions](https://github.com/microbiomedata/nmdc-field-notes/actions) to ensure that pushing the version tag triggered the workflow which creates a new GitHub Release and that it completed successfully.
 5. If proceeding to create Android or iOS builds, run another production build.
-    ```shell
-    ionic capacitor sync --prod
-    ```
+   ```shell
+   ionic capacitor sync --prod
+   ```
 
 #### Create and Distribute a new Android Build
 
@@ -266,24 +267,25 @@ Creating a release involves three steps: creating a new version tag and GitHub R
 
 1. Obtain two passwords from other developers: the keystore decryption password and the keystore password. Save these securely in a password manager.
 2. Download the encrypted keystore file from NERSC.
-    ```shell
-    scp <user>@dtn01.nersc.gov:/global/cfs/cdirs/m3408/nmdc-field-notes/android-keystore/org.microbiomedata.fieldnotes.keystore.tar.gz.enc .
-    ```
+   ```shell
+   scp <user>@dtn01.nersc.gov:/global/cfs/cdirs/m3408/nmdc-field-notes/android-keystore/org.microbiomedata.fieldnotes.keystore.tar.gz.enc .
+   ```
 3. Decrypt the keystore file into the `android` directory. Enter the keystore decryption password when prompted.
-    ```shell
-    openssl enc -d -aes256 -pbkdf2 -in ./org.microbiomedata.fieldnotes.keystore.tar.gz.enc | tar xz -C ./android
-    ```
+   ```shell
+   openssl enc -d -aes256 -pbkdf2 -in ./org.microbiomedata.fieldnotes.keystore.tar.gz.enc | tar xz -C ./android
+   ```
 4. Remove the encrypted keystore file.
-    ```shell
-    rm org.microbiomedata.fieldnotes.keystore.tar.gz.enc
-    ```
+   ```shell
+   rm org.microbiomedata.fieldnotes.keystore.tar.gz.enc
+   ```
+
 </details>
 
 1. If you are **not** continuing from the version tag section, checkout the version tag and run a production build.
-    ```shell
-    git checkout vX.Y.Z  # replace with the version tag
-    ionic capacitor sync --prod
-    ```
+   ```shell
+   git checkout vX.Y.Z  # replace with the version tag
+   ionic capacitor sync --prod
+   ```
 2. Build the Android APK file.
    1. Open the Android project in Android Studio.
       ```shell
@@ -292,10 +294,10 @@ Creating a release involves three steps: creating a new version tag and GitHub R
    2. In the toolbar, click `Build` > `Generate Signed App Bundle / APK...`
    3. Select "APK" and click "Next"
    4. Enter the following information and click "Next"
-       - Key store path: `<project root>/android/org.microbiomedata.fieldnotes.keystore`
-       - Key store password: `<keystore password>`
-       - Key alias: `nmdc field notes`
-       - Key password: `<keystore password>`
+      - Key store path: `<project root>/android/org.microbiomedata.fieldnotes.keystore`
+      - Key store password: `<keystore password>`
+      - Key alias: `nmdc field notes`
+      - Key password: `<keystore password>`
    5. Select the "release" build variant and click "Create"
    6. Wait for the gradle build to complete. Look for notification saying "Build completed successfully for module 'android.app.main' with 1 build variant."
 3. Distribute the APK file via the GitHub Release.
@@ -311,15 +313,15 @@ Creating a release involves three steps: creating a new version tag and GitHub R
 > These instructions are based around distributing via TestFlight for the beta release period. These will be updated later to include App Store distribution once a stable release is ready.
 
 1. If you are **not** continuing from the version tag section, checkout the version tag and run a production build.
-    ```shell
-    git checkout vX.Y.Z  # replace with the version tag
-    ionic capacitor sync --prod
-    ```
+   ```shell
+   git checkout vX.Y.Z  # replace with the version tag
+   ionic capacitor sync --prod
+   ```
 2. Create the iOS build:
    1. Open the iOS project in Xcode.
-       ```shell
-       ionic capacitor open ios
-       ``` 
+      ```shell
+      ionic capacitor open ios
+      ```
    2. "[Create an archive of the app](https://developer.apple.com/documentation/xcode/distributing-your-app-for-beta-testing-and-releases#Create-an-archive-of-your-app)" by clicking (in the toolbar) `Product` > `Archive`
    3. "[Select the method of distribution](https://developer.apple.com/documentation/xcode/distributing-your-app-for-beta-testing-and-releases#Select-a-method-for-distribution)" to be TestFlight & App Store
    4. Click the "Validate App" button to validate the build with respect to App Store Connect

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Here's how you can introduce a new environment variable to the code base:
 
 ### Make a release
 
-Creating a release involves three steps: creating a new version tag and GitHub Release, creating and distributing a new Android build, creating and distributing a new iOS build.
+Creating a release involves three steps: creating a new version tag and GitHub Release, creating and distributing a new Android build, and creating and distributing a new iOS build.
 
 #### Create Version Tag and GitHub Release
 
@@ -244,7 +244,7 @@ Creating a release involves three steps: creating a new version tag and GitHub R
    ```shell
    ionic capacitor sync --prod
    ```
-3. Decide whether the new version will be a patch, minor, or major version. Then run the following to create a new version commit and tag.
+3. Decide whether the new version will be a patch, minor, or major version. Then, run the following commands to create a new version commit and tag.
 
    > [!NOTE]
    > During the beta testing period, use only minor or patch versions.
@@ -254,7 +254,7 @@ Creating a release involves three steps: creating a new version tag and GitHub R
    git push && git push --tags
    ```
 
-4. Check [GitHub Actions](https://github.com/microbiomedata/nmdc-field-notes/actions) to ensure that pushing the version tag triggered the workflow which creates a new GitHub Release and that it completed successfully.
+4. Check [GitHub Actions](https://github.com/microbiomedata/nmdc-field-notes/actions) to ensure that pushing the version tag triggered the workflow that creates a new GitHub Release, and that that workflow completed successfully.
 5. If proceeding to create Android or iOS builds, run another production build.
    ```shell
    ionic capacitor sync --prod
@@ -305,7 +305,7 @@ Creating a release involves three steps: creating a new version tag and GitHub R
       ```shell
       cp android/app/release/app-release.apk org.microbiomedata.fieldnotes-vX.Y.Z.apk  # replace with version number
       ```
-   2. Edit the vX.Y.Z [GitHub Release](https://github.com/microbiomedata/nmdc-field-notes/releases) and attach the `org.microbiomedata.fieldnotes-vX.Y.Z.apk` file.
+   2. Edit the vX.Y.Z [GitHub Release](https://github.com/microbiomedata/nmdc-field-notes/releases) and attach the `org.microbiomedata.fieldnotes-vX.Y.Z.apk` file to it.
 
 #### Create and Distribute a new iOS Build
 

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -16,8 +16,7 @@
 bin/
 gen/
 out/
-#  Uncomment the following line in case you need and you don't have the release build type files in your app
-# release/
+release/
 
 # Gradle files
 .gradle/
@@ -53,9 +52,8 @@ captures/
 .idea/navEditor.xml
 
 # Keystore files
-# Uncomment the following lines if you do not want to check your keystore files in.
-#*.jks
-#*.keystore
+*.jks
+*.keystore
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.5.2",
+        "@trapezedev/configure": "^7.0.10",
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",
         "@types/react-router": "^5.1.20",
@@ -5856,6 +5857,137 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@trapezedev/configure": {
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/@trapezedev/configure/-/configure-7.0.10.tgz",
+      "integrity": "sha512-6bhaLpfjSImamthENrtaWntL0MxAFZjKrZOnsQdZ/ae2gVOvhdxTlPGnrIAnVQsRVkEjRB2B8Ih1oHYI/fq9kg==",
+      "dev": true,
+      "dependencies": {
+        "@ionic/cli-framework-output": "^2.2.2",
+        "@ionic/utils-fs": "^3.1.5",
+        "@ionic/utils-subprocess": "^2.1.8",
+        "@ionic/utils-terminal": "^2.3.1",
+        "@prettier/plugin-xml": "^1.1.0",
+        "@trapezedev/project": "7.0.10",
+        "@types/fs-extra": "^9.0.13",
+        "@types/jest": "^27.0.2",
+        "@types/lodash": "^4.14.175",
+        "@types/plist": "^3.0.2",
+        "@types/prompts": "^2.0.14",
+        "@types/slice-ansi": "^5.0.0",
+        "commander": "^8.2.0",
+        "conventional-changelog": "^3.1.4",
+        "env-paths": "^3.0.0",
+        "kleur": "^4.1.4",
+        "lodash": "^4.17.21",
+        "npm-watch": "^0.9.0",
+        "plist": "^3.0.4",
+        "prompts": "^2.4.2",
+        "replace": "^1.1.0",
+        "tmp": "^0.2.1",
+        "ts-node": "^10.2.1",
+        "yaml": "^1.10.2",
+        "yargs": "^17.2.1"
+      },
+      "bin": {
+        "trapeze": "bin/trapeze"
+      }
+    },
+    "node_modules/@trapezedev/configure/node_modules/@prettier/plugin-xml": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-1.2.0.tgz",
+      "integrity": "sha512-bFvVAZKs59XNmntYjyefn3K4TBykS6E+d6ZW8IcylAs88ZO+TzLhp0dPpi0VKfPzq1Nb+kpDnPRTiwb4zY6NgA==",
+      "dev": true,
+      "dependencies": {
+        "@xml-tools/parser": "^1.0.11",
+        "prettier": ">=2.3"
+      }
+    },
+    "node_modules/@trapezedev/configure/node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@trapezedev/configure/node_modules/@types/jest": {
+      "version": "27.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.2.tgz",
+      "integrity": "sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==",
+      "dev": true,
+      "dependencies": {
+        "jest-matcher-utils": "^27.0.0",
+        "pretty-format": "^27.0.0"
+      }
+    },
+    "node_modules/@trapezedev/configure/node_modules/@types/slice-ansi": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/slice-ansi/-/slice-ansi-5.0.2.tgz",
+      "integrity": "sha512-IfxMqRjS0zNRHlbDgfMnYRW4LgYMjb+0XeVuMrC0H7/krAGeaQFQ1A4ijuEpmXT+KUspgzjQ2wFUO+xuCZao4A==",
+      "dev": true
+    },
+    "node_modules/@trapezedev/configure/node_modules/diff-sequences": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
+      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
+      "dev": true,
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@trapezedev/configure/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@trapezedev/configure/node_modules/jest-diff": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
+      "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^27.5.1",
+        "jest-get-type": "^27.5.1",
+        "pretty-format": "^27.5.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@trapezedev/configure/node_modules/jest-get-type": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
+      "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
+      "dev": true,
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@trapezedev/configure/node_modules/jest-matcher-utils": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz",
+      "integrity": "sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^27.5.1",
+        "jest-get-type": "^27.5.1",
+        "pretty-format": "^27.5.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/@trapezedev/gradle-parse": {
       "version": "7.0.10",
       "dev": true,
@@ -6277,10 +6409,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/plist": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
+      "integrity": "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "xmlbuilder": ">=11.0.1"
+      }
+    },
     "node_modules/@types/pretty-hrtime": {
       "version": "1.0.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/prompts": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.4.9.tgz",
+      "integrity": "sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "kleur": "^3.0.3"
+      }
+    },
+    "node_modules/@types/prompts/node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
@@ -21289,6 +21450,15 @@
       "version": "3.1.1",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "test.unit": "vitest",
     "lint": "eslint src",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "preversion": "vitest run",
+    "version": "APP_VERSION=$npm_package_version trapeze run trapeze.config.yaml -y && git add android ios"
   },
   "dependencies": {
     "@capacitor/android": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",
+    "@trapezedev/configure": "^7.0.10",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "@types/react-router": "^5.1.20",

--- a/trapeze.config.yaml
+++ b/trapeze.config.yaml
@@ -1,0 +1,13 @@
+vars:
+  APP_VERSION:
+    default: 0.0.0
+
+platforms:
+  android:
+    incrementVersionCode: true
+    versionName: $APP_VERSION
+  ios:
+    targets:
+      App:
+        incrementBuild: true
+        version: $APP_VERSION


### PR DESCRIPTION
Fixes #148 

These changes add a section to the README about making and distributing releases. They also add a bit of automation to eliminate a few manual steps -- although there are still plenty of them 😬.

In other projects we initiate the release process by creating a GitHub Release. This one is kind of the inverse. Because of the updates that need to be made to `package.json` and various native project files (in the `android` and `ios` directories), it turns out to be simpler to create those changes _locally_ and automatically create the GitHub Release when those local changes are pushed to GitHub.

At a high level the process looks like this:

1. Use the `npm version` command to update `package.json` and create a new version tag. 
    * The new `version` script in `package.json` introduced here uses [Trapeze](https://trapeze.dev/) to keep the native projects' version and build numbers updated, as well, during this process.
    * Once the new version tag is pushed to GitHub, a new GitHub Actions workflow is responsible for creating a GitHub Release based on that tag.
2. Use Android Studio to generate a new APK file and attach that APK file to the GitHub Release.
3. Use Xcode to generate the iOS build and distribute it via TestFlight.

Thoughts about Trapeze:

* I have some minor misgivings about using something that doesn't seem to be _super_ actively maintained. Nonetheless, it seems to do what we need it to do and still better than writing something ourselves.
* Right now the Trapeze config is only set up to manage version and build numbers. It _can_ manage other things we might be interested in like [names](https://trapeze.dev/docs/Operations/ios#displayname), [custom URI schemes](https://trapeze.dev/docs/Operations/ios#plist), etc. Something to consider in the future.

Thoughts on testing:

* I've tried to test the pieces of the process as much as possible without _actually_ creating or distributing new releases. If the process seems sensible, maybe next week we can try actually following it all the way through to work out any final kinks.