### PR TITLE
Improved offline support and API error indicators

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation project(':capacitor-geolocation')
     implementation project(':capacitor-haptics')
     implementation project(':capacitor-keyboard')
+    implementation project(':capacitor-network')
     implementation project(':capacitor-splash-screen')
     implementation project(':capacitor-status-bar')
 

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -17,6 +17,9 @@ project(':capacitor-haptics').projectDir = new File('../node_modules/@capacitor/
 include ':capacitor-keyboard'
 project(':capacitor-keyboard').projectDir = new File('../node_modules/@capacitor/keyboard/android')
 
+include ':capacitor-network'
+project(':capacitor-network').projectDir = new File('../node_modules/@capacitor/network/android')
+
 include ':capacitor-splash-screen'
 project(':capacitor-splash-screen').projectDir = new File('../node_modules/@capacitor/splash-screen/android')
 

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -16,6 +16,7 @@ def capacitor_pods
   pod 'CapacitorGeolocation', :path => '../../node_modules/@capacitor/geolocation'
   pod 'CapacitorHaptics', :path => '../../node_modules/@capacitor/haptics'
   pod 'CapacitorKeyboard', :path => '../../node_modules/@capacitor/keyboard'
+  pod 'CapacitorNetwork', :path => '../../node_modules/@capacitor/network'
   pod 'CapacitorSplashScreen', :path => '../../node_modules/@capacitor/splash-screen'
   pod 'CapacitorStatusBar', :path => '../../node_modules/@capacitor/status-bar'
 end

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -12,6 +12,8 @@ PODS:
     - Capacitor
   - CapacitorKeyboard (6.0.0):
     - Capacitor
+  - CapacitorNetwork (6.0.1):
+    - Capacitor
   - CapacitorSplashScreen (6.0.0):
     - Capacitor
   - CapacitorStatusBar (6.0.0):
@@ -25,6 +27,7 @@ DEPENDENCIES:
   - "CapacitorGeolocation (from `../../node_modules/@capacitor/geolocation`)"
   - "CapacitorHaptics (from `../../node_modules/@capacitor/haptics`)"
   - "CapacitorKeyboard (from `../../node_modules/@capacitor/keyboard`)"
+  - "CapacitorNetwork (from `../../node_modules/@capacitor/network`)"
   - "CapacitorSplashScreen (from `../../node_modules/@capacitor/splash-screen`)"
   - "CapacitorStatusBar (from `../../node_modules/@capacitor/status-bar`)"
 
@@ -43,6 +46,8 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/haptics"
   CapacitorKeyboard:
     :path: "../../node_modules/@capacitor/keyboard"
+  CapacitorNetwork:
+    :path: "../../node_modules/@capacitor/network"
   CapacitorSplashScreen:
     :path: "../../node_modules/@capacitor/splash-screen"
   CapacitorStatusBar:
@@ -56,9 +61,10 @@ SPEC CHECKSUMS:
   CapacitorGeolocation: 1f12bbe372b65116e851bd8e3a94cf0ef9bacebb
   CapacitorHaptics: 9ebc9363f0e9b8eb4295088a0b474530acf1859b
   CapacitorKeyboard: deacbd09d8d1029c3681197fb05d206b721d5f73
+  CapacitorNetwork: 5c94acfdddc22043f2ffaff224ce9b4aa5a179f0
   CapacitorSplashScreen: 5431ab8d19c1c6e95777d53bfaa7a36a6c3d94c7
   CapacitorStatusBar: 2e4369f99166125435641b1908d05f561eaba6f6
 
-PODFILE CHECKSUM: 07e49214a5b7fe2d734d8cccf4663dfda80f50c3
+PODFILE CHECKSUM: a1f47640694a5257caf6710a4915d48188bf1b90
 
 COCOAPODS: 1.15.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@capacitor/haptics": "^6.0.0",
         "@capacitor/ios": "^6.0.0",
         "@capacitor/keyboard": "^6.0.0",
+        "@capacitor/network": "^6.0.1",
         "@capacitor/splash-screen": "^6.0.0",
         "@capacitor/status-bar": "^6.0.0",
         "@ionic/react": "^8.0.1",
@@ -2239,6 +2240,14 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@capacitor/keyboard/-/keyboard-6.0.0.tgz",
       "integrity": "sha512-pPX/PQWWjw5ce47kHEYv6IWlHzuhAxgXihqEAAAGLdwK3u3srgGWCljXrYS9juVBPi/lA1uK7UaUzYI0XrgxVQ==",
+      "peerDependencies": {
+        "@capacitor/core": "^6.0.0"
+      }
+    },
+    "node_modules/@capacitor/network": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/network/-/network-6.0.1.tgz",
+      "integrity": "sha512-j+C1khUchNVol3HQGOhHKRAQ3Sc4DumzF8YVJqbkAkfOMHLWr/9g2H/P61yzqEr5kcidpOgWbBwQugHRv7o+7g==",
       "peerDependencies": {
         "@capacitor/core": "^6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@capacitor/haptics": "^6.0.0",
     "@capacitor/ios": "^6.0.0",
     "@capacitor/keyboard": "^6.0.0",
+    "@capacitor/network": "^6.0.1",
     "@capacitor/splash-screen": "^6.0.0",
     "@capacitor/status-bar": "^6.0.0",
     "@ionic/react": "^8.0.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { IonApp, setupIonicReact } from "@ionic/react";
 import ColorSchemePreferenceMonitor from "./components/ColorSchemePreferenceMonitor/ColorSchemePreferenceMonitor";
 import QueryClientProvider from "./QueryClientProvider";
+import NetworkStatusProvider from "./NetworkStatus";
 import Router from "./Router";
 import StoreProvider from "./Store";
 
@@ -44,14 +45,16 @@ setupIonicReact();
 
 const App: React.FC = () => {
   return (
-    <StoreProvider>
-      <QueryClientProvider>
-        <IonApp>
-          <ColorSchemePreferenceMonitor />
-          <Router />
-        </IonApp>
-      </QueryClientProvider>
-    </StoreProvider>
+    <NetworkStatusProvider>
+      <StoreProvider>
+        <QueryClientProvider>
+          <IonApp>
+            <ColorSchemePreferenceMonitor />
+            <Router />
+          </IonApp>
+        </QueryClientProvider>
+      </StoreProvider>
+    </NetworkStatusProvider>
   );
 };
 

--- a/src/NetworkStatus.tsx
+++ b/src/NetworkStatus.tsx
@@ -1,0 +1,62 @@
+import React, {
+  createContext,
+  PropsWithChildren,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import { Network } from "@capacitor/network";
+import { PluginListenerHandle } from "@capacitor/core";
+
+interface NetworkStatusContextValue {
+  isOnline: boolean;
+}
+
+const NetworkStatusContext = createContext<NetworkStatusContextValue>({
+  isOnline: true,
+});
+
+const NetworkStatusProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const [isOnline, setIsOnline] = useState(true);
+
+  useEffect(() => {
+    // Used to prevent setting up the listener from being added from an unmounted component
+    let ignore = false;
+    let listener: PluginListenerHandle | null = null;
+
+    async function addNetworkListener() {
+      const currentStatus = await Network.getStatus();
+      // If the component is unmounted before the previous await finishes, ignore the result and
+      // no not set up a listener.
+      if (ignore) {
+        return;
+      }
+      setIsOnline(currentStatus.connected);
+
+      listener = await Network.addListener("networkStatusChange", (status) => {
+        setIsOnline(status.connected);
+      });
+    }
+
+    void addNetworkListener();
+
+    return () => {
+      if (listener) {
+        void listener.remove();
+      }
+      ignore = true;
+    };
+  }, []);
+
+  return (
+    <NetworkStatusContext.Provider value={{ isOnline }}>
+      {children}
+    </NetworkStatusContext.Provider>
+  );
+};
+
+export default NetworkStatusProvider;
+
+export const useNetworkStatus = () => {
+  return useContext(NetworkStatusContext);
+};

--- a/src/NetworkStatus.tsx
+++ b/src/NetworkStatus.tsx
@@ -7,6 +7,7 @@ import React, {
 } from "react";
 import { Network } from "@capacitor/network";
 import { PluginListenerHandle } from "@capacitor/core";
+import { onlineManager } from "@tanstack/react-query";
 
 interface NetworkStatusContextValue {
   isOnline: boolean;
@@ -31,9 +32,11 @@ const NetworkStatusProvider: React.FC<PropsWithChildren> = ({ children }) => {
       if (ignore) {
         return;
       }
+      onlineManager.setOnline(currentStatus.connected);
       setIsOnline(currentStatus.connected);
 
       listener = await Network.addListener("networkStatusChange", (status) => {
+        onlineManager.setOnline(currentStatus.connected);
         setIsOnline(status.connected);
       });
     }
@@ -48,6 +51,7 @@ const NetworkStatusProvider: React.FC<PropsWithChildren> = ({ children }) => {
     };
   }, []);
 
+  // Don't render the children until we know for certain the initial online status
   if (isOnline === null) {
     return null;
   }

--- a/src/NetworkStatus.tsx
+++ b/src/NetworkStatus.tsx
@@ -17,7 +17,7 @@ const NetworkStatusContext = createContext<NetworkStatusContextValue>({
 });
 
 const NetworkStatusProvider: React.FC<PropsWithChildren> = ({ children }) => {
-  const [isOnline, setIsOnline] = useState(true);
+  const [isOnline, setIsOnline] = useState<boolean | null>(null);
 
   useEffect(() => {
     // Used to prevent setting up the listener from being added from an unmounted component
@@ -47,6 +47,10 @@ const NetworkStatusProvider: React.FC<PropsWithChildren> = ({ children }) => {
       ignore = true;
     };
   }, []);
+
+  if (isOnline === null) {
+    return null;
+  }
 
   return (
     <NetworkStatusContext.Provider value={{ isOnline }}>

--- a/src/NetworkStatus.tsx
+++ b/src/NetworkStatus.tsx
@@ -22,14 +22,14 @@ const NetworkStatusProvider: React.FC<PropsWithChildren> = ({ children }) => {
 
   useEffect(() => {
     // Used to prevent setting up the listener from being added from an unmounted component
-    let ignore = false;
+    let isComponentUnmounted = false;
     let listener: PluginListenerHandle | null = null;
 
     async function addNetworkListener() {
       const initialStatus = await Network.getStatus();
       // If the component is unmounted before the previous await finishes, ignore the result and
       // do not set up a listener.
-      if (ignore) {
+      if (isComponentUnmounted) {
         return;
       }
 
@@ -58,7 +58,7 @@ const NetworkStatusProvider: React.FC<PropsWithChildren> = ({ children }) => {
       }
 
       // Always flag the component as unmounted when the cleanup function is called.
-      ignore = true;
+      isComponentUnmounted = true;
     };
   }, []);
 

--- a/src/QueryClientProvider.tsx
+++ b/src/QueryClientProvider.tsx
@@ -9,11 +9,13 @@ import { useStore } from "./Store";
 import { createAsyncStoragePersister } from "@tanstack/query-async-storage-persister";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
+const GARBAGE_COLLECTION_TIME = 1000 * 60 * 60 * 24 * 7; // 1 week
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 1000 * 20, // 20 seconds
-      gcTime: 1000 * 60 * 60 * 24 * 7, // 1 week
+      gcTime: GARBAGE_COLLECTION_TIME,
       retry: 0,
     },
   },
@@ -42,10 +44,10 @@ const QueryClientProvider: React.FC<PropsWithChildren> = ({ children }) => {
   return (
     <PersistQueryClientProvider
       client={queryClient}
-      persistOptions={{ persister: persister, maxAge: Infinity }}
+      persistOptions={{ persister: persister, maxAge: GARBAGE_COLLECTION_TIME }}
       onSuccess={() => {
         queryClient.resumePausedMutations().then(() => {
-          queryClient.invalidateQueries();
+          void queryClient.invalidateQueries();
         });
       }}
     >

--- a/src/QueryClientProvider.tsx
+++ b/src/QueryClientProvider.tsx
@@ -8,7 +8,6 @@ import { addDefaultMutationFns } from "./queries";
 import { useStore } from "./Store";
 import { createAsyncStoragePersister } from "@tanstack/query-async-storage-persister";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import config from "./config";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -20,15 +19,6 @@ const queryClient = new QueryClient({
   },
 });
 addDefaultMutationFns(queryClient);
-
-// See: https://tanstack.com/query/latest/docs/framework/react/devtools#devtools-in-production
-const ReactQueryDevtoolsProduction = React.lazy(() =>
-  import("@tanstack/react-query-devtools/build/modern/production.js").then(
-    (d) => ({
-      default: d.ReactQueryDevtools,
-    }),
-  ),
-);
 
 const QueryClientProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const { store } = useStore();
@@ -61,11 +51,6 @@ const QueryClientProvider: React.FC<PropsWithChildren> = ({ children }) => {
     >
       {children}
       <ReactQueryDevtools initialIsOpen={false} />
-      {config.SHOW_DEV_TOOLS_IN_PROD && (
-        <React.Suspense fallback={null}>
-          <ReactQueryDevtoolsProduction />
-        </React.Suspense>
-      )}
     </PersistQueryClientProvider>
   );
 };

--- a/src/QueryClientProvider.tsx
+++ b/src/QueryClientProvider.tsx
@@ -44,7 +44,7 @@ const QueryClientProvider: React.FC<PropsWithChildren> = ({ children }) => {
   return (
     <PersistQueryClientProvider
       client={queryClient}
-      persistOptions={{ persister: persister, maxAge: GARBAGE_COLLECTION_TIME }}
+      persistOptions={{ persister: persister, maxAge: Infinity }}
       onSuccess={() => {
         queryClient.resumePausedMutations().then(() => {
           void queryClient.invalidateQueries();

--- a/src/QueryClientProvider.tsx
+++ b/src/QueryClientProvider.tsx
@@ -8,6 +8,7 @@ import { addDefaultMutationFns } from "./queries";
 import { useStore } from "./Store";
 import { createAsyncStoragePersister } from "@tanstack/query-async-storage-persister";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import config from "./config";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -19,6 +20,15 @@ const queryClient = new QueryClient({
   },
 });
 addDefaultMutationFns(queryClient);
+
+// See: https://tanstack.com/query/latest/docs/framework/react/devtools#devtools-in-production
+const ReactQueryDevtoolsProduction = React.lazy(() =>
+  import("@tanstack/react-query-devtools/build/modern/production.js").then(
+    (d) => ({
+      default: d.ReactQueryDevtools,
+    }),
+  ),
+);
 
 const QueryClientProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const { store } = useStore();
@@ -51,6 +61,11 @@ const QueryClientProvider: React.FC<PropsWithChildren> = ({ children }) => {
     >
       {children}
       <ReactQueryDevtools initialIsOpen={false} />
+      {config.SHOW_DEV_TOOLS_IN_PROD && (
+        <React.Suspense fallback={null}>
+          <ReactQueryDevtoolsProduction />
+        </React.Suspense>
+      )}
     </PersistQueryClientProvider>
   );
 };

--- a/src/Store.test.tsx
+++ b/src/Store.test.tsx
@@ -65,6 +65,7 @@ const TestStoreConsumer: React.FC = () => {
 
 const renderTestStoreConsumer = () => {
   const setTokensSpy = vi.spyOn(nmdcServerClient, "setTokens");
+  const setRefreshTokenSpy = vi.spyOn(nmdcServerClient, "setRefreshToken");
   const user = userEvent.setup();
 
   render(
@@ -76,6 +77,7 @@ const renderTestStoreConsumer = () => {
   return {
     user,
     setTokensSpy,
+    setRefreshTokenSpy,
     elements: {
       storeStatus: screen.getByTestId("store-status"),
       isLoggedIn: screen.getByTestId("is-logged-in"),
@@ -159,19 +161,18 @@ describe("Store", () => {
     );
 
     // Render the test component
-    const { elements, setTokensSpy } = renderTestStoreConsumer();
+    const { elements, setRefreshTokenSpy, setTokensSpy } =
+      renderTestStoreConsumer();
 
     // Verify that the store gets initialized with the pre-populated token and that it is used to
     // perform a token exchange
     await waitFor(() =>
       expect(elements.storeStatus.textContent).toBe("store created"),
     );
-    expect(elements.isLoggedIn.textContent).toBe("true");
+    await waitFor(() => expect(elements.isLoggedIn.textContent).toBe("true"));
     expect(elements.loggedInUser.textContent).toBe("Test Testerson");
-    expect(setTokensSpy).toHaveBeenCalledWith(
-      "refreshed-access-token",
-      "from-storage",
-    );
+    expect(setRefreshTokenSpy).toHaveBeenCalledWith("from-storage");
+    expect(setTokensSpy).toHaveBeenCalledWith("refreshed-access-token");
   });
 
   it("should not hydrate the refresh token from storage if the token exchange fails", async () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -418,7 +418,7 @@ class NmdcServerClient extends FetchClient {
       return this.exchangeRefreshTokenCache;
     }
     if (this.refreshToken === null) {
-      throw new Error("No refresh token");
+      throw new Error("No refresh token found");
     }
     const response = this.fetchJson<TokenResponse>("/auth/refresh", {
       method: "POST",

--- a/src/components/ErrorBanner/ErrorBanner.module.css
+++ b/src/components/ErrorBanner/ErrorBanner.module.css
@@ -1,0 +1,7 @@
+.errorDetails {
+  background-color: color-mix(
+    in srgb,
+    var(--ion-color-danger),
+    transparent 85%
+  );
+}

--- a/src/components/ErrorBanner/ErrorBanner.tsx
+++ b/src/components/ErrorBanner/ErrorBanner.tsx
@@ -1,0 +1,65 @@
+import React, { PropsWithChildren, useState } from "react";
+import Banner from "../Banner/Banner";
+import { IonButton, IonLabel } from "@ionic/react";
+import { ApiError } from "../../api";
+import config from "../../config";
+
+import styles from "./ErrorBanner.module.css";
+
+const { SUPPORT_EMAIL } = config;
+
+function formatError(error: Error): string {
+  let formatted = `${error.name}: ${error.message}`;
+  if (error instanceof ApiError) {
+    formatted += `\n\nRequest: ${error.request.method} ${error.request.url}`;
+    formatted += `\n\nResponse: ${error.response.status} ${error.response.statusText}`;
+    formatted += `\n${error.responseBody}`;
+  }
+  return formatted;
+}
+
+interface ErrorBannerProps extends PropsWithChildren {
+  error: Error;
+}
+
+const ErrorBanner: React.FC<ErrorBannerProps> = ({ error, children }) => {
+  const [isErrorDetailShown, setIsErrorDetailShown] = useState(false);
+
+  const formattedError = formatError(error);
+  const emailBody = encodeURIComponent(
+    `I encountered the following error while using the app:\n\n${formattedError}`,
+  );
+
+  return (
+    <>
+      <Banner color="danger">
+        <IonLabel>{children}</IonLabel>
+        <IonButton
+          slot="end"
+          fill="clear"
+          onClick={() => setIsErrorDetailShown((prev) => !prev)}
+        >
+          {isErrorDetailShown ? "Hide" : "Show"} Details
+        </IonButton>
+      </Banner>
+      {isErrorDetailShown && (
+        <div className={`ion-padding ${styles.errorDetails}`}>
+          An unexpected error occurred while communicating with the server.
+          Please try again later. If the problem persists, please email{" "}
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href={`mailto:${SUPPORT_EMAIL}?subject=Field Notes Error&body=${emailBody}`}
+          >
+            {SUPPORT_EMAIL}
+          </a>
+          <hr />
+          Technical details: <br />
+          <pre>{formattedError}</pre>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ErrorBanner;

--- a/src/components/FixedCenteredMessage/FixedCenteredMessage.module.css
+++ b/src/components/FixedCenteredMessage/FixedCenteredMessage.module.css
@@ -1,4 +1,4 @@
-div[slot="fixed"] {
+.message {
   top: 50%;
   width: 100%;
   text-align: center;

--- a/src/components/FixedCenteredMessage/FixedCenteredMessage.tsx
+++ b/src/components/FixedCenteredMessage/FixedCenteredMessage.tsx
@@ -1,0 +1,13 @@
+import React, { PropsWithChildren } from "react";
+
+import styles from "./FixedCenteredMessage.module.css";
+
+const FixedCenteredMessage: React.FC<PropsWithChildren> = ({ children }) => {
+  return (
+    <div slot="fixed" className={styles.message}>
+      {children}
+    </div>
+  );
+};
+
+export default FixedCenteredMessage;

--- a/src/components/MutationErrorBanner/MutationErrorBanner.test.tsx
+++ b/src/components/MutationErrorBanner/MutationErrorBanner.test.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import {
+  QueryClient,
+  QueryClientProvider,
+  useMutation,
+  UseMutationResult,
+} from "@tanstack/react-query";
+import config from "../../config";
+import { render, screen, waitFor } from "@testing-library/react";
+import MutationErrorBanner from "./MutationErrorBanner";
+import userEvent from "@testing-library/user-event";
+import { FakeErrorTestClient } from "../../mocks/fixtures";
+
+const client = new FakeErrorTestClient();
+const queryClient = new QueryClient();
+
+interface Props {
+  mutation: UseMutationResult<Response, Error, void, unknown>;
+}
+const TestComponent: React.FC<Props> = ({ mutation }) => {
+  return (
+    <>
+      <button onClick={() => mutation.mutate()}>Trigger Mutation</button>
+      <div data-testid="mutation-status">{mutation.status}</div>
+      <div data-testid="error-banner">
+        <MutationErrorBanner mutation={mutation}>
+          Mutation Failed
+        </MutationErrorBanner>
+      </div>
+    </>
+  );
+};
+
+const ErrorTest: React.FC = () => {
+  const mutation = useMutation({
+    mutationFn: () => client.postError(),
+  });
+  return <TestComponent mutation={mutation} />;
+};
+
+const SuccessTest: React.FC = () => {
+  const mutation = useMutation({
+    mutationFn: () => client.postSuccess(),
+  });
+  return <TestComponent mutation={mutation} />;
+};
+
+test("MutationErrorBanner renders nothing when mutation idle", async () => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ErrorTest />
+    </QueryClientProvider>,
+  );
+
+  // Before the mutation is triggered, the error banner should not be visible
+  expect(screen.getByTestId("mutation-status").textContent).toBe("idle");
+  expect(screen.getByTestId("error-banner").textContent).toBe("");
+});
+
+test("MutationErrorBanner renders nothing while the mutation is pending", async () => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ErrorTest />
+    </QueryClientProvider>,
+  );
+
+  // When a mutation has been triggered but hasn't yet settled, the error banner should not be
+  // visible
+  await userEvent.click(screen.getByText("Trigger Mutation"));
+  expect(screen.getByTestId("mutation-status").textContent).toBe("pending");
+  expect(screen.getByTestId("error-banner").textContent).toBe("");
+});
+
+test("MutationErrorBanner renders nothing when the mutation succeeds", async () => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <SuccessTest />
+    </QueryClientProvider>,
+  );
+
+  await userEvent.click(screen.getByText("Trigger Mutation"));
+
+  // Once a successful mutation settles, the error banner should not be visible
+  await waitFor(() =>
+    expect(screen.getByTestId("mutation-status").textContent).toBe("success"),
+  );
+  expect(screen.getByTestId("error-banner").textContent).toBe("");
+});
+
+test("MutationErrorBanner renders error message when mutation fails", async () => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ErrorTest />
+    </QueryClientProvider>,
+  );
+
+  await userEvent.click(screen.getByText("Trigger Mutation"));
+
+  // Once a failing mutation settles the error banner should be visible with the message determined
+  // by the component's children and should *not* be showing technical details (like the status
+  // code)
+  await waitFor(() =>
+    expect(screen.getByTestId("mutation-status").textContent).toBe("error"),
+  );
+  const errorBanner = screen.getByTestId("error-banner");
+  expect(errorBanner.textContent).toContain("Mutation Failed");
+  expect(errorBanner.textContent).not.toContain("500");
+
+  // Once the user clicks the "Show Details" button the error banner should show the technical
+  // details
+  const showDetailsButton = screen.getByText("Show Details");
+  await userEvent.click(showDetailsButton);
+  expect(errorBanner.textContent).toContain("500");
+  expect(errorBanner.textContent).toContain("Something bad happened");
+  expect(errorBanner.textContent).toContain(config.SUPPORT_EMAIL);
+});

--- a/src/components/MutationErrorBanner/MutationErrorBanner.tsx
+++ b/src/components/MutationErrorBanner/MutationErrorBanner.tsx
@@ -1,0 +1,22 @@
+import React, { PropsWithChildren } from "react";
+import { UseMutationResult } from "@tanstack/react-query";
+import ErrorBanner from "../ErrorBanner/ErrorBanner";
+
+interface MutationErrorBannerProps extends PropsWithChildren {
+  // Not clear why the `any` can't be replaced by `unknown` here.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mutation: UseMutationResult<unknown, Error, any, unknown>;
+}
+
+const MutationErrorBanner: React.FC<MutationErrorBannerProps> = ({
+  mutation,
+  children,
+}) => {
+  if (mutation.status !== "error") {
+    return null;
+  }
+
+  return <ErrorBanner error={mutation.error}>{children}</ErrorBanner>;
+};
+
+export default MutationErrorBanner;

--- a/src/components/QueryErrorBanner/QueryErrorBanner.test.tsx
+++ b/src/components/QueryErrorBanner/QueryErrorBanner.test.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+  UseQueryResult,
+} from "@tanstack/react-query";
+import config from "../../config";
+import { render, screen, waitFor } from "@testing-library/react";
+import QueryErrorBanner from "./QueryErrorBanner";
+import userEvent from "@testing-library/user-event";
+import { FakeErrorTestClient } from "../../mocks/fixtures";
+
+const client = new FakeErrorTestClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+interface Props {
+  query: UseQueryResult;
+}
+const TestComponent: React.FC<Props> = ({ query }) => {
+  return (
+    <>
+      <div data-testid="query-status">{query.status}</div>
+      <div data-testid="error-banner">
+        <QueryErrorBanner query={query}>Query Failed</QueryErrorBanner>
+      </div>
+    </>
+  );
+};
+
+const ErrorTest: React.FC = () => {
+  const queryError = useQuery({
+    queryKey: ["test-error"],
+    queryFn: () => client.getError(),
+  });
+  return <TestComponent query={queryError} />;
+};
+
+const SuccessTest: React.FC = () => {
+  const querySuccess = useQuery({
+    queryKey: ["test-success"],
+    queryFn: () => client.getSuccess(),
+  });
+  return <TestComponent query={querySuccess} />;
+};
+
+test("QueryErrorBanner renders nothing when query is fetching", async () => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ErrorTest />
+    </QueryClientProvider>,
+  );
+
+  // Before the query settles, the error banner should not be visible
+  expect(screen.getByTestId("query-status").textContent).toBe("pending");
+  expect(screen.getByTestId("error-banner").textContent).toBe("");
+});
+
+test("QueryErrorBanner renders nothing when query is successful", async () => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <SuccessTest />
+    </QueryClientProvider>,
+  );
+
+  // After a successful query settles, the error banner should not be visible
+  await waitFor(() =>
+    expect(screen.getByTestId("query-status").textContent).toBe("success"),
+  );
+  expect(screen.getByTestId("error-banner").textContent).toBe("");
+});
+
+test("QueryErrorBanner renders error message when query fails", async () => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ErrorTest />
+    </QueryClientProvider>,
+  );
+
+  // Once a failing query settles the error banner should be visible with the message determined by
+  // the component's children and should *not* be showing technical details (like the status code)
+  await waitFor(() =>
+    expect(screen.getByTestId("query-status").textContent).toBe("error"),
+  );
+  const errorBanner = screen.getByTestId("error-banner");
+  expect(errorBanner.textContent).toContain("Query Failed");
+  expect(errorBanner.textContent).not.toContain("500");
+
+  // Once the user clicks the "Show Details" button the error banner should show the technical
+  // details
+  const showDetailsButton = screen.getByText("Show Details");
+  await userEvent.click(showDetailsButton);
+  expect(errorBanner.textContent).toContain("500");
+  expect(errorBanner.textContent).toContain("Something bad happened");
+  expect(errorBanner.textContent).toContain(config.SUPPORT_EMAIL);
+});

--- a/src/components/QueryErrorBanner/QueryErrorBanner.tsx
+++ b/src/components/QueryErrorBanner/QueryErrorBanner.tsx
@@ -1,0 +1,20 @@
+import React, { PropsWithChildren } from "react";
+import { UseQueryResult } from "@tanstack/react-query";
+import ErrorBanner from "../ErrorBanner/ErrorBanner";
+
+interface QueryErrorBannerProps extends PropsWithChildren {
+  query: UseQueryResult;
+}
+
+const QueryErrorBanner: React.FC<QueryErrorBannerProps> = ({
+  query,
+  children,
+}) => {
+  if (query.fetchStatus !== "idle" || query.status !== "error") {
+    return null;
+  }
+
+  return <ErrorBanner error={query.error}>{children}</ErrorBanner>;
+};
+
+export default QueryErrorBanner;

--- a/src/components/SampleSlotEditModal/SampleSlotEditModal.tsx
+++ b/src/components/SampleSlotEditModal/SampleSlotEditModal.tsx
@@ -310,9 +310,9 @@ const SampleSlotEditModal: React.FC<SampleSlotEditModalProps> = ({
                 <IonButton
                   fill="outline"
                   expand="block"
-                  // Call dismiss here instead of onCancel directly so that the modal can animate
-                  // out of view before the onCancel handler is called via the IonModalDidDismiss
-                  // event
+                  // Call `dismiss` here instead of `onCancel` directly so that the modal can animate
+                  // out of view before the `onCancel` handler is called via the `IonModalDidDismiss`
+                  // event.
                   onClick={() => modal.current?.dismiss()}
                 >
                   Cancel

--- a/src/components/StudyList/StudyList.tsx
+++ b/src/components/StudyList/StudyList.tsx
@@ -17,6 +17,7 @@ import Pluralize from "../Pluralize/Pluralize";
 import { getSubmissionSamples } from "../../utils";
 import paths from "../../paths";
 import NoneOr from "../NoneOr/NoneOr";
+import QueryErrorBanner from "../QueryErrorBanner/QueryErrorBanner";
 
 const StudyList: React.FC = () => {
   const submissionList = useSubmissionList();
@@ -37,6 +38,10 @@ const StudyList: React.FC = () => {
 
   return (
     <>
+      <QueryErrorBanner query={submissionList}>
+        Error loading studies
+      </QueryErrorBanner>
+
       <IonListHeader>
         <IonLabel>Studies</IonLabel>
         <IonButton routerLink={paths.studyCreate}>New</IonButton>
@@ -46,53 +51,58 @@ const StudyList: React.FC = () => {
         <IonRefresherContent />
       </IonRefresher>
 
-      {concatenatedSubmissions.length === 0 ? (
-        <IonText color="medium" className="ion-padding">
-          No studies yet
-        </IonText>
-      ) : (
-        <>
-          <IonList>
-            {concatenatedSubmissions.map((submission) => (
-              <IonItem
-                key={submission.id}
-                routerLink={paths.studyView(submission.id)}
-              >
-                <IonLabel>
-                  <h3>
-                    <NoneOr placeholder="No study name">
-                      {submission.metadata_submission.studyForm.studyName}
-                    </NoneOr>
-                  </h3>
-                  <p>
-                    <NoneOr placeholder="No template selected">
-                      {submission.metadata_submission.templates[0]}
-                    </NoneOr>
-                    {" • "}
-                    <Pluralize
-                      count={getSubmissionSamples(submission).length}
-                      singular="Sample"
-                      showCount
-                    />
-                  </p>
-                </IonLabel>
-              </IonItem>
-            ))}
-          </IonList>
+      {submissionList.data &&
+        (concatenatedSubmissions.length === 0 ? (
+          <IonText color="medium" className="ion-padding">
+            No studies yet
+          </IonText>
+        ) : (
+          <>
+            <IonList>
+              {concatenatedSubmissions.map((submission) => (
+                <IonItem
+                  key={submission.id}
+                  routerLink={paths.studyView(submission.id)}
+                >
+                  <IonLabel>
+                    <h3>
+                      <NoneOr placeholder="No study name">
+                        {submission.metadata_submission.studyForm.studyName}
+                      </NoneOr>
+                    </h3>
+                    <p>
+                      <NoneOr placeholder="No template selected">
+                        {submission.metadata_submission.templates[0]}
+                      </NoneOr>
+                      {" • "}
+                      <Pluralize
+                        count={getSubmissionSamples(submission).length}
+                        singular="Sample"
+                        showCount
+                      />
+                    </p>
+                  </IonLabel>
+                </IonItem>
+              ))}
+            </IonList>
 
-          {submissionList.hasNextPage && (
-            <IonButton
-              fill="clear"
-              expand="block"
-              className="ion-padding-horizontal ion-padding-bottom"
-              disabled={submissionList.isFetching}
-              onClick={() => submissionList.fetchNextPage()}
-            >
-              {submissionList.isFetchingNextPage ? <IonSpinner /> : "Load More"}
-            </IonButton>
-          )}
-        </>
-      )}
+            {submissionList.hasNextPage && (
+              <IonButton
+                fill="clear"
+                expand="block"
+                className="ion-padding-horizontal ion-padding-bottom"
+                disabled={submissionList.isFetching}
+                onClick={() => submissionList.fetchNextPage()}
+              >
+                {submissionList.isFetchingNextPage ? (
+                  <IonSpinner />
+                ) : (
+                  "Load More"
+                )}
+              </IonButton>
+            )}
+          </>
+        ))}
     </>
   );
 };

--- a/src/components/StudyList/StudyList.tsx
+++ b/src/components/StudyList/StudyList.tsx
@@ -6,8 +6,11 @@ import {
   IonLabel,
   IonList,
   IonListHeader,
+  IonRefresher,
+  IonRefresherContent,
   IonSpinner,
   IonText,
+  RefresherEventDetail,
 } from "@ionic/react";
 import { SubmissionMetadata } from "../../api";
 import Pluralize from "../Pluralize/Pluralize";
@@ -27,12 +30,21 @@ const StudyList: React.FC = () => {
     );
   }, [submissionList.data]);
 
+  const handleRefresh = async (event: CustomEvent<RefresherEventDetail>) => {
+    await submissionList.refetch();
+    event.detail.complete();
+  };
+
   return (
     <>
       <IonListHeader>
         <IonLabel>Studies</IonLabel>
         <IonButton routerLink={paths.studyCreate}>New</IonButton>
       </IonListHeader>
+
+      <IonRefresher slot="fixed" onIonRefresh={handleRefresh}>
+        <IonRefresherContent />
+      </IonRefresher>
 
       {concatenatedSubmissions.length === 0 ? (
         <IonText color="medium" className="ion-padding">

--- a/src/components/StudyList/StudyList.tsx
+++ b/src/components/StudyList/StudyList.tsx
@@ -35,16 +35,6 @@ const StudyList: React.FC = () => {
         <IonButton routerLink={paths.studyCreate}>New</IonButton>
       </IonListHeader>
 
-      <IonProgressBar
-        type="indeterminate"
-        style={{
-          visibility:
-            submissionList.isFetching || submissionList.isLoading
-              ? "visible"
-              : "hidden",
-        }}
-      />
-
       {concatenatedSubmissions.length === 0 ? (
         <IonText color="medium" className="ion-padding">
           No studies yet

--- a/src/components/StudyList/StudyList.tsx
+++ b/src/components/StudyList/StudyList.tsx
@@ -6,7 +6,6 @@ import {
   IonLabel,
   IonList,
   IonListHeader,
-  IonProgressBar,
   IonSpinner,
   IonText,
 } from "@ionic/react";

--- a/src/components/StudyView/StudyView.tsx
+++ b/src/components/StudyView/StudyView.tsx
@@ -7,6 +7,7 @@ import SampleList from "../SampleList/SampleList";
 import { getSubmissionSamples } from "../../utils";
 import { produce } from "immer";
 import paths from "../../paths";
+import { useNetworkStatus } from "../../NetworkStatus";
 
 interface StudyViewProps {
   submissionId: string;
@@ -19,16 +20,19 @@ const StudyView: React.FC<StudyViewProps> = ({ submissionId }) => {
     updateMutation,
     lockMutation,
   } = useSubmission(submissionId);
+  const { isOnline } = useNetworkStatus();
 
   const handleSampleCreate = async () => {
     if (!submission.data) {
       return;
     }
 
-    try {
-      await lockMutation.mutateAsync(submissionId);
-    } catch {
-      return;
+    if (isOnline) {
+      try {
+        await lockMutation.mutateAsync(submissionId);
+      } catch {
+        return;
+      }
     }
 
     const updatedSubmission = produce(submission.data, (draft) => {

--- a/src/components/StudyView/StudyView.tsx
+++ b/src/components/StudyView/StudyView.tsx
@@ -1,12 +1,6 @@
 import React from "react";
 import { useSubmission } from "../../queries";
-import {
-  IonItem,
-  IonLabel,
-  IonList,
-  IonProgressBar,
-  useIonRouter,
-} from "@ionic/react";
+import { IonItem, IonLabel, IonList, useIonRouter } from "@ionic/react";
 import SectionHeader from "../SectionHeader/SectionHeader";
 import NoneOr from "../NoneOr/NoneOr";
 import SampleList from "../SampleList/SampleList";

--- a/src/components/StudyView/StudyView.tsx
+++ b/src/components/StudyView/StudyView.tsx
@@ -1,6 +1,14 @@
 import React from "react";
 import { useSubmission } from "../../queries";
-import { IonItem, IonLabel, IonList, useIonRouter } from "@ionic/react";
+import {
+  IonItem,
+  IonLabel,
+  IonList,
+  IonRefresher,
+  IonRefresherContent,
+  RefresherEventDetail,
+  useIonRouter,
+} from "@ionic/react";
 import SectionHeader from "../SectionHeader/SectionHeader";
 import NoneOr from "../NoneOr/NoneOr";
 import SampleList from "../SampleList/SampleList";
@@ -53,8 +61,17 @@ const StudyView: React.FC<StudyViewProps> = ({ submissionId }) => {
     });
   };
 
+  const handleRefresh = async (event: CustomEvent<RefresherEventDetail>) => {
+    await submission.refetch();
+    event.detail.complete();
+  };
+
   return (
     <>
+      <IonRefresher slot="fixed" onIonRefresh={handleRefresh}>
+        <IonRefresherContent />
+      </IonRefresher>
+
       {submission.data && (
         <>
           <IonList className="ion-padding-bottom">

--- a/src/components/StudyView/StudyView.tsx
+++ b/src/components/StudyView/StudyView.tsx
@@ -57,16 +57,6 @@ const StudyView: React.FC<StudyViewProps> = ({ submissionId }) => {
 
   return (
     <>
-      <IonProgressBar
-        type="indeterminate"
-        style={{
-          visibility:
-            submission.isFetching || submission.isLoading
-              ? "visible"
-              : "hidden",
-        }}
-      />
-
       {submission.data && (
         <>
           <IonList className="ion-padding-bottom">

--- a/src/components/StudyView/StudyView.tsx
+++ b/src/components/StudyView/StudyView.tsx
@@ -16,6 +16,8 @@ import { getSubmissionSamples } from "../../utils";
 import { produce } from "immer";
 import paths from "../../paths";
 import { useNetworkStatus } from "../../NetworkStatus";
+import QueryErrorBanner from "../QueryErrorBanner/QueryErrorBanner";
+import MutationErrorBanner from "../MutationErrorBanner/MutationErrorBanner";
 
 interface StudyViewProps {
   submissionId: string;
@@ -68,6 +70,13 @@ const StudyView: React.FC<StudyViewProps> = ({ submissionId }) => {
 
   return (
     <>
+      <QueryErrorBanner query={submission}>
+        Error loading study
+      </QueryErrorBanner>
+      <MutationErrorBanner mutation={updateMutation}>
+        Error adding sample
+      </MutationErrorBanner>
+
       <IonRefresher slot="fixed" onIonRefresh={handleRefresh}>
         <IonRefresherContent />
       </IonRefresher>

--- a/src/components/ThemedToolbar/ThemedToolbar.module.css
+++ b/src/components/ThemedToolbar/ThemedToolbar.module.css
@@ -16,3 +16,19 @@ ion-toolbar.themedBackground {
       url("../../theme/NMDC_microbe_dark.png");
   }
 }
+
+ion-toolbar.offlineToolbar {
+  --min-height: 1.25rem;
+}
+
+.offlineWarning {
+  font-size: 0.875rem;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+
+  & ion-icon {
+    margin-right: 4px;
+  }
+}

--- a/src/components/ThemedToolbar/ThemedToolbar.module.css
+++ b/src/components/ThemedToolbar/ThemedToolbar.module.css
@@ -32,3 +32,9 @@ ion-toolbar.offlineToolbar {
     margin-right: 4px;
   }
 }
+
+.loadingBar {
+  position: absolute;
+  bottom: 0;
+  z-index: 11;
+}

--- a/src/components/ThemedToolbar/ThemedToolbar.tsx
+++ b/src/components/ThemedToolbar/ThemedToolbar.tsx
@@ -1,15 +1,19 @@
 import React from "react";
-import { IonIcon, IonToolbar } from "@ionic/react";
+import { IonIcon, IonProgressBar, IonToolbar } from "@ionic/react";
 import { cloudOfflineOutline } from "ionicons/icons";
 import { useNetworkStatus } from "../../NetworkStatus";
 
 import classes from "./ThemedToolbar.module.css";
+import { useIsFetching, useIsMutating } from "@tanstack/react-query";
 
 interface ThemedToolbarProps extends React.ComponentProps<typeof IonToolbar> {}
 
 const ThemedToolbar: React.FC<ThemedToolbarProps> = (props) => {
   const { isOnline } = useNetworkStatus();
   const { children, ...rest } = props;
+  const isFetching = useIsFetching();
+  const isMutating = useIsMutating();
+
   return (
     <>
       {!isOnline && (
@@ -23,6 +27,12 @@ const ThemedToolbar: React.FC<ThemedToolbarProps> = (props) => {
       <IonToolbar {...rest} className={classes.themedBackground}>
         {children}
       </IonToolbar>
+      <IonProgressBar
+        type="indeterminate"
+        style={{
+          visibility: isFetching || isMutating ? "visible" : "hidden",
+        }}
+      />
     </>
   );
 };

--- a/src/components/ThemedToolbar/ThemedToolbar.tsx
+++ b/src/components/ThemedToolbar/ThemedToolbar.tsx
@@ -12,7 +12,7 @@ const ThemedToolbar: React.FC<ThemedToolbarProps> = (props) => {
   const { isOnline } = useNetworkStatus();
   const { children, ...rest } = props;
   const isFetching = useIsFetching();
-  const isMutating = useIsMutating();
+  const isMutating = useIsMutating({ predicate: (m) => !m.state.isPaused });
 
   return (
     <>
@@ -27,12 +27,9 @@ const ThemedToolbar: React.FC<ThemedToolbarProps> = (props) => {
       <IonToolbar {...rest} className={classes.themedBackground}>
         {children}
       </IonToolbar>
-      <IonProgressBar
-        type="indeterminate"
-        style={{
-          visibility: isFetching || isMutating ? "visible" : "hidden",
-        }}
-      />
+      {(isFetching > 0 || isMutating > 0) && (
+        <IonProgressBar className={classes.loadingBar} type="indeterminate" />
+      )}
     </>
   );
 };

--- a/src/components/ThemedToolbar/ThemedToolbar.tsx
+++ b/src/components/ThemedToolbar/ThemedToolbar.tsx
@@ -1,12 +1,30 @@
 import React from "react";
-import { IonToolbar } from "@ionic/react";
+import { IonIcon, IonToolbar } from "@ionic/react";
+import { cloudOfflineOutline } from "ionicons/icons";
+import { useNetworkStatus } from "../../NetworkStatus";
 
 import classes from "./ThemedToolbar.module.css";
 
 interface ThemedToolbarProps extends React.ComponentProps<typeof IonToolbar> {}
 
 const ThemedToolbar: React.FC<ThemedToolbarProps> = (props) => {
-  return <IonToolbar {...props} className={classes.themedBackground} />;
+  const { isOnline } = useNetworkStatus();
+  const { children, ...rest } = props;
+  return (
+    <>
+      {!isOnline && (
+        <IonToolbar color="medium" className={classes.offlineToolbar}>
+          <div className={classes.offlineWarning}>
+            <IonIcon icon={cloudOfflineOutline} />
+            <div>You are offline</div>
+          </div>
+        </IonToolbar>
+      )}
+      <IonToolbar {...rest} className={classes.themedBackground}>
+        {children}
+      </IonToolbar>
+    </>
+  );
 };
 
 export default ThemedToolbar;

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,7 +15,6 @@ const env = import.meta.env;
 interface Config {
   APP_VERSION: typeof env.PACKAGE_VERSION;
   NMDC_SERVER_API_URL: string;
-  SHOW_DEV_TOOLS_IN_PROD: boolean;
 }
 
 const config: Config = {
@@ -33,13 +32,6 @@ const config: Config = {
    */
   NMDC_SERVER_API_URL:
     env.VITE_NMDC_SERVER_API_URL || "https://data-dev.microbiomedata.org",
-
-  /**
-   * Boolean indicating whether to show React Query dev tools in production builds.
-   *
-   * This can be useful for debugging while running on device simulators.
-   */
-  SHOW_DEV_TOOLS_IN_PROD: env.VITE_SHOW_DEV_TOOLS_IN_PROD || false,
 };
 
 export default config;

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ const env = import.meta.env;
 interface Config {
   APP_VERSION: typeof env.PACKAGE_VERSION;
   NMDC_SERVER_API_URL: string;
+  SHOW_DEV_TOOLS_IN_PROD: boolean;
 }
 
 const config: Config = {
@@ -32,6 +33,13 @@ const config: Config = {
    */
   NMDC_SERVER_API_URL:
     env.VITE_NMDC_SERVER_API_URL || "https://data-dev.microbiomedata.org",
+
+  /**
+   * Boolean indicating whether to show React Query dev tools in production builds.
+   *
+   * This can be useful for debugging while running on device simulators.
+   */
+  SHOW_DEV_TOOLS_IN_PROD: env.VITE_SHOW_DEV_TOOLS_IN_PROD || false,
 };
 
 export default config;

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ const env = import.meta.env;
 interface Config {
   APP_VERSION: typeof env.PACKAGE_VERSION;
   NMDC_SERVER_API_URL: string;
+  SUPPORT_EMAIL: string;
 }
 
 const config: Config = {
@@ -32,6 +33,11 @@ const config: Config = {
    */
   NMDC_SERVER_API_URL:
     env.VITE_NMDC_SERVER_API_URL || "https://data-dev.microbiomedata.org",
+
+  /**
+   * Support email address.
+   */
+  SUPPORT_EMAIL: env.VITE_SUPPORT_EMAIL || "support@microbiomedata.org",
 };
 
 export default config;

--- a/src/mocks/fixtures.ts
+++ b/src/mocks/fixtures.ts
@@ -1,5 +1,6 @@
-import { SubmissionMetadata } from "../api";
+import { FetchClient, SubmissionMetadata } from "../api";
 import { initAddressForm, initContextForm, initMultiOmicsForm } from "../data";
+import config from "../config";
 
 export function generateSubmission(
   numberOfSamples: number,
@@ -197,3 +198,27 @@ export const submissions: SubmissionMetadata[] = [
     source_client: "field_notes",
   },
 ];
+
+export class FakeErrorTestClient extends FetchClient {
+  private static readonly successEndpoint = "/_fake-error-tester";
+  private static readonly errorEndpoint = "/_fake-error-tester?status=500";
+  constructor() {
+    super(config.NMDC_SERVER_API_URL);
+  }
+  getSuccess() {
+    return this.fetch(FakeErrorTestClient.successEndpoint);
+  }
+  getError() {
+    return this.fetch(FakeErrorTestClient.errorEndpoint);
+  }
+  postSuccess() {
+    return this.fetch(FakeErrorTestClient.successEndpoint, {
+      method: "POST",
+    });
+  }
+  postError() {
+    return this.fetch(FakeErrorTestClient.errorEndpoint, {
+      method: "POST",
+    });
+  }
+}

--- a/src/mocks/fixtures.ts
+++ b/src/mocks/fixtures.ts
@@ -199,6 +199,15 @@ export const submissions: SubmissionMetadata[] = [
   },
 ];
 
+/**
+ * This is a subclass of FetchClient (similar to NmdcServerClient) that is used for testing error
+ * handling. It calls endpoints that are only defined on the mock server used by tests (i.e. "fake")
+ * and that do not exist on the real NMDC server.
+ *
+ * See also:
+ * - `fakeErrorHandlers` in src/mocks/server.ts
+ * - src/components/QueryErrorBanner/QueryErrorBanner.test.tsx
+ */
 export class FakeErrorTestClient extends FetchClient {
   private static readonly successEndpoint = "/_fake-error-tester";
   private static readonly errorEndpoint = "/_fake-error-tester?status=500";

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -18,7 +18,7 @@ export function resetFixtureData() {
   submissions = submissionsFixture;
 }
 
-export const handlers = [
+const handlers = [
   http.get<
     Record<string, never>,
     Record<string, never>,
@@ -135,6 +135,26 @@ export const handlers = [
   ),
 ];
 
+// These do not correspond to anything in the actual nmdc-server API. They are just convenience
+// endpoints used for testing. See also: FakeErrorTestClient in fixtures.ts.
+const fakeErrorHandlers = [
+  http.all(`${NMDC_SERVER_API_URL}/_fake-error-tester`, async ({ request }) => {
+    const url = new URL(request.url);
+    const status = parseInt(url.searchParams.get("status") || "200");
+    // This delay helps to test transitions between loading, error, and success states
+    await delay(100);
+    return HttpResponse.json(
+      {
+        detail: status < 300 ? "Everything is fine" : "Something bad happened",
+      },
+      { status },
+    );
+  }),
+];
+handlers.push(...fakeErrorHandlers);
+
+// The remaining handlers are used to test specific error conditions, so they are not added to the
+// mock server by default. Instead they are imported and used in specific test files.
 export const patchMetadataSubmissionError = http.patch<{ id: string }>(
   `${NMDC_SERVER_API_URL}/api/metadata_submission/:id`,
   async () => {

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { IonContent, IonHeader, IonPage, IonTitle } from "@ionic/react";
-import "./HomePage.css";
 import StudyList from "../../components/StudyList/StudyList";
 import ThemedToolbar from "../../components/ThemedToolbar/ThemedToolbar";
 import { useStore } from "../../Store";
 import { initiateLogin } from "../../auth";
+import FixedCenteredMessage from "../../components/FixedCenteredMessage/FixedCenteredMessage";
 
 const HEADER_TEXT = "NMDC Field Notes";
 
@@ -21,9 +21,9 @@ const HomePage: React.FC = () => {
         {isLoggedIn ? (
           <StudyList />
         ) : (
-          <div slot="fixed">
+          <FixedCenteredMessage>
             <a onClick={initiateLogin}>Log in</a> to view and edit studies
-          </div>
+          </FixedCenteredMessage>
         )}
       </IonContent>
     </IonPage>

--- a/src/pages/SamplePage/SamplePage.tsx
+++ b/src/pages/SamplePage/SamplePage.tsx
@@ -32,6 +32,7 @@ import ThemedToolbar from "../../components/ThemedToolbar/ThemedToolbar";
 import Banner from "../../components/Banner/Banner";
 import { useNetworkStatus } from "../../NetworkStatus";
 import { useIsSubmissionEditable } from "../../useIsSubmissionEditable";
+import MutationErrorBanner from "../../components/MutationErrorBanner/MutationErrorBanner";
 
 interface SamplePageParams {
   submissionId: string;
@@ -188,6 +189,11 @@ const SamplePage: React.FC = () => {
     });
   };
 
+  const handleModalCancel = () => {
+    setModalSlot(null);
+    updateMutation.reset();
+  };
+
   return (
     <IonPage>
       <IonHeader>
@@ -253,9 +259,14 @@ const SamplePage: React.FC = () => {
             <SampleSlotEditModal
               defaultValue={modalSlot && sample?.[modalSlot.name]}
               disabled={!loggedInUserCanEdit}
+              errorBanner={
+                <MutationErrorBanner mutation={updateMutation}>
+                  Error saving sample
+                </MutationErrorBanner>
+              }
               getSlotValue={getSlotValue}
               goldEcosystemTree={schema.data.goldEcosystemTree}
-              onCancel={() => setModalSlot(null)}
+              onCancel={handleModalCancel}
               onSave={handleSave}
               onChange={handleModalValueChange}
               saving={isOnline && updateMutation.isPending}

--- a/src/pages/SamplePage/SamplePage.tsx
+++ b/src/pages/SamplePage/SamplePage.tsx
@@ -104,7 +104,7 @@ const SamplePage: React.FC = () => {
       onSuccess: () => setModalSlot(null),
     });
     if (!isOnline) {
-      // If we're offline, the updateMutation will stay in a paused state and not fire onSuccess
+      // If we're offline, the `updateMutation` will stay in a paused state and not fire `onSuccess`
       // until we go back online. So we need to manually close the modal here.
       setModalSlot(null);
     }

--- a/src/pages/StudyCreatePage/StudyCreatePage.tsx
+++ b/src/pages/StudyCreatePage/StudyCreatePage.tsx
@@ -16,12 +16,15 @@ import paths from "../../paths";
 import { initSubmission } from "../../data";
 import { checkmark } from "ionicons/icons";
 import ThemedToolbar from "../../components/ThemedToolbar/ThemedToolbar";
+import { useNetworkStatus } from "../../NetworkStatus";
+import FixedCenteredMessage from "../../components/FixedCenteredMessage/FixedCenteredMessage";
 
 const StudyCreatePage: React.FC = () => {
   const router = useIonRouter();
   const [present] = useIonToast();
   const submissionCreate = useSubmissionCreate();
   const submission = useMemo(initSubmission, []);
+  const { isOnline } = useNetworkStatus();
 
   const handleSave = async (submission: SubmissionMetadataCreate) => {
     submissionCreate.mutate(submission, {
@@ -47,7 +50,14 @@ const StudyCreatePage: React.FC = () => {
         </ThemedToolbar>
       </IonHeader>
       <IonContent>
-        <StudyForm submission={submission} onSave={handleSave} />
+        {isOnline ? (
+          <StudyForm submission={submission} onSave={handleSave} />
+        ) : (
+          <FixedCenteredMessage>
+            Study creation is disabled while offline. Please try again when
+            online.
+          </FixedCenteredMessage>
+        )}
       </IonContent>
     </IonPage>
   );

--- a/src/pages/StudyEditPage/StudyEditPage.tsx
+++ b/src/pages/StudyEditPage/StudyEditPage.tsx
@@ -11,7 +11,6 @@ import {
   IonList,
   IonPage,
   IonPopover,
-  IonProgressBar,
   IonTitle,
   useIonAlert,
   useIonRouter,

--- a/src/pages/StudyEditPage/StudyEditPage.tsx
+++ b/src/pages/StudyEditPage/StudyEditPage.tsx
@@ -80,23 +80,32 @@ const StudyEditPage: React.FC = () => {
   };
 
   const handleDeleteInitiate = () => {
-    presentAlert({
-      header: "Delete Study",
-      message:
-        "Are you sure you want to delete this study? All associated sample data will be deleted as well.",
-      buttons: [
-        "Cancel",
-        {
-          text: "Delete",
-          handler: () => {
-            isDeleting.current = true;
-            deleteMutation.mutate(submissionId, {
-              onSuccess: () => router.push(paths.home, "back"),
-            });
+    if (isOnline) {
+      presentAlert({
+        header: "Delete Study",
+        message:
+          "Are you sure you want to delete this study? All associated sample data will be deleted as well.",
+        buttons: [
+          "Cancel",
+          {
+            text: "Delete",
+            handler: () => {
+              isDeleting.current = true;
+              deleteMutation.mutate(submissionId, {
+                onSuccess: () => router.push(paths.home, "back"),
+              });
+            },
           },
-        },
-      ],
-    });
+        ],
+      });
+    } else {
+      presentAlert({
+        header: "Delete Study",
+        message:
+          "Study deletion is disabled while offline. Please try again when online.",
+        buttons: ["OK"],
+      });
+    }
   };
 
   return (

--- a/src/pages/StudyEditPage/StudyEditPage.tsx
+++ b/src/pages/StudyEditPage/StudyEditPage.tsx
@@ -149,18 +149,6 @@ const StudyEditPage: React.FC = () => {
           </Banner>
         )}
 
-        <IonProgressBar
-          type="indeterminate"
-          style={{
-            visibility:
-              submission.isFetching ||
-              submission.isLoading ||
-              lockMutation.isPending
-                ? "visible"
-                : "hidden",
-          }}
-        />
-
         {submission.data && (
           <StudyForm
             disabled={!loggedInUserCanEdit}

--- a/src/pages/StudyEditPage/StudyEditPage.tsx
+++ b/src/pages/StudyEditPage/StudyEditPage.tsx
@@ -32,6 +32,7 @@ import ThemedToolbar from "../../components/ThemedToolbar/ThemedToolbar";
 import Banner from "../../components/Banner/Banner";
 import { useNetworkStatus } from "../../NetworkStatus";
 import { useIsSubmissionEditable } from "../../useIsSubmissionEditable";
+import MutationErrorBanner from "../../components/MutationErrorBanner/MutationErrorBanner";
 
 interface StudyEditPageParams {
   submissionId: string;
@@ -120,6 +121,13 @@ const StudyEditPage: React.FC = () => {
         </ThemedToolbar>
       </IonHeader>
       <IonContent>
+        <MutationErrorBanner mutation={updateMutation}>
+          Error saving study
+        </MutationErrorBanner>
+        <MutationErrorBanner mutation={deleteMutation}>
+          Error deleting study
+        </MutationErrorBanner>
+
         <IonPopover
           trigger="ellipsis-menu-trigger"
           triggerAction="click"

--- a/src/queries.test.tsx
+++ b/src/queries.test.tsx
@@ -7,7 +7,6 @@ import {
 import { act, renderHook, waitFor } from "@testing-library/react";
 import {
   addDefaultMutationFns,
-  useCurrentUser,
   useSubmission,
   useSubmissionCreate,
   useSubmissionList,
@@ -45,13 +44,6 @@ const createWrapper = () => {
 
 const TEST_ID_1 = "00000000-0000-0000-0000-000000000001";
 const TEST_ID_2 = "00000000-0000-0000-0000-000000000002";
-
-test("useCurrentUser should return data from the query", async () => {
-  const wrapper = createWrapper();
-  const { result } = renderHook(() => useCurrentUser(), { wrapper });
-  await waitFor(() => expect(result.current.isSuccess).toBe(true));
-  expect(result.current.data?.name).toBe("Test Testerson");
-});
 
 test("useSubmissionList should return data from the query", async () => {
   const wrapper = createWrapper();

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -302,7 +302,7 @@ export function useSubmissionCreate() {
   >({
     mutationKey: submissionKeys.create(),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: submissionKeys.list() });
+      return queryClient.invalidateQueries({ queryKey: submissionKeys.list() });
     },
   });
   return mutation;

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -19,10 +19,6 @@ import {
 } from "./api";
 import { produce } from "immer";
 
-export const userKeys = {
-  user: () => ["user"],
-};
-
 export const submissionKeys = {
   all: () => ["submissions"],
   list: () => [...submissionKeys.all(), "list"],

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -265,7 +265,7 @@ export function useSubmission(id: string) {
         // If the lock operation failed due to a conflict, the submission is already locked.
         // The lock information is included in the error response, so update the submission
         // data in the cache with the lock information.
-        const body = (await error.response.json()) as LockOperationResult;
+        const body = JSON.parse(error.responseBody) as LockOperationResult;
         updateLockStatusForSubmission(id, body);
       }
     },

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -111,13 +111,6 @@ export function addDefaultMutationFns(queryClient: QueryClient) {
   });
 }
 
-export function useCurrentUser() {
-  return useQuery({
-    queryKey: userKeys.user(),
-    queryFn: () => nmdcServerClient.getCurrentUser(),
-  });
-}
-
 const PAGE_SIZE = 10;
 
 export function useSubmissionList() {

--- a/src/useIsSubmissionEditable.ts
+++ b/src/useIsSubmissionEditable.ts
@@ -17,8 +17,9 @@ export function useIsSubmissionEditable(submission?: SubmissionMetadata) {
   }
 
   // If someone is logged in and is offline, there is no way they can claim the lock so just
-  // assume that no one else is editing. This may result in data clobbering once this user goes
-  // back online.
+  // assume that no one else is editing.
+  // 
+  // WARNING: This may result in data clobbering once this user goes back online.
   if (!isOnline) {
     return true;
   }

--- a/src/useIsSubmissionEditable.ts
+++ b/src/useIsSubmissionEditable.ts
@@ -18,7 +18,7 @@ export function useIsSubmissionEditable(submission?: SubmissionMetadata) {
 
   // If someone is logged in and is offline, there is no way they can claim the lock so just
   // assume that no one else is editing.
-  // 
+  //
   // WARNING: This may result in data clobbering once this user goes back online.
   if (!isOnline) {
     return true;

--- a/src/useIsSubmissionEditable.ts
+++ b/src/useIsSubmissionEditable.ts
@@ -1,0 +1,32 @@
+import { useStore } from "./Store";
+import { SubmissionMetadata } from "./api";
+import { useNetworkStatus } from "./NetworkStatus";
+
+/**
+ * Determine if a submission is editable by the logged-in user, taking network status into account.
+ *
+ * @param submission
+ */
+export function useIsSubmissionEditable(submission?: SubmissionMetadata) {
+  const { loggedInUser } = useStore();
+  const { isOnline } = useNetworkStatus();
+
+  // If no user is logged in, the submission is not editable
+  if (loggedInUser === null) {
+    return false;
+  }
+
+  // If someone is logged in and is offline, there is no way they can claim the lock so just
+  // assume that no one else is editing. This may result in data clobbering once this user goes
+  // back online.
+  if (!isOnline) {
+    return true;
+  }
+
+  // If someone is logged in and is online, check to see if the lock is available or if the lock is
+  // held by the logged-in user.
+  return (
+    submission?.locked_by === null ||
+    submission?.locked_by?.id === loggedInUser.id
+  );
+}


### PR DESCRIPTION
Fixes #42 

### Summary

This is a bit of a pick-n-mix of change all in the neighborhood of API error messaging _and_ offline support, since those two things are closely related. The expected functionality can be boiled down to:

* While offline:
  * Do not allow requests to create or delete a submission. This might be erring on the defensive side, but I think allowing those would lead to more weird edge cases than we're prepared to handle right now.
  * Do allow requests to update a submission. Such requests will be paused until the client is back online. Successive requests to update to the same submission should replace earlier requests so that one cumulative update request per submission goes out later.
  * Skip the requests to lock and unlock submissions. While offline we know that such a request can't be fulfilled, so in order to allow updates we simply have to _presume_ that the lock is available.
* While online
  * Let all requests go out across the network. 
  * If any network request (query or mutation) is in progress, show a top-level loading indicator
  * If a network request fails (because the server is unreachable _or_ the server responded with a non-2xx status), show an error indicator to the user
  * A failed query should _not_ prevent cached data from being shown

### Details

* The new `NetworkStatusProvider` provides a single `isOnline` boolean value which can be accessed through the `useNetworkStatus` hook. Under the hood this provider uses the `@capacitor/network` plugin to get the initial online status and setup a lister to respond to changes in online status. React Query has its own [OnlineManager](https://tanstack.com/query/latest/docs/reference/onlineManager) which is how it knows when to pause or retry requests. However, I found there were certain cases where React Query wasn't as reliable as Capacitor at detecting connection changes. So the `NetworkStatusProvider` also attempts to keep them in sync by manually setting React Query's network status.
* The initialization of `StoreProvider` has been updated to account for cases where the app starts up while offline. Specifically: 
  * When a user logs in, store _all_ of their user details in persistent storage (in addition to their refresh token, which was all that was previously stored)
  * When the app starts up, if user details are found in persistent storage use them to set the logged-in user state.
  * When the app starts up, if a refresh token is found in persistent storage immediately provide it to the `nmdc-server` API client. Previously this happened only _after_ a successful token exchange took place (which obviously can't happen if the app starts while offline).
  * When the app starts up _and_ we're online, attempt the token exchange and fetch updated user details from the server. If the app starts up while offline, this token exchange won't happen. Instead, when the client does go online, the first network request will go out and fail with an `Unauthorized` response, the client will detect that, perform the token exchange at that point, and then retry the request. That logic was in place before, but the API client didn't have the refresh token it needed (see previous bullet point).
* Instances of `IonProgressBar` have been removed individual components (e.g. `StudyList`). Instead, one _global_ `IonProgressBar` has been added to `ThemedToolbar`. It responds to _any_ query or mutation managed by React Query. `ThemedToolbar` has also been updated to show a banner when the user is offline.
* Two new components, `QueryErrorBanner` and `MutationErrorBanner`, are responsible for displaying error messages when network requests fail. Both of those components are thin wrappers around the new `ErrorBanner` component, which is responsible for actually formatting the error message. This component does show (although not by default) the nitty-gritty technical details of the failed request. I have mixed feelings about this, but I have a feeling it might be useful at least during the beta testing period.

| ![image](https://github.com/user-attachments/assets/d048aeb8-a164-4cd5-967d-108c96ab4a24) | ![image](https://github.com/user-attachments/assets/c2869fc6-2aa3-4c64-88c1-4b9464c4e879) |
| --- | --- |

* I added a [pull-to-refresh](https://ionicframework.com/docs/api/refresher) capability to the study list and individual study pages. Even though React Query is pretty smart about refetching at the right time, I think it's just comforting to be able to refresh on demand.
* Lots of little logic changes around when certain requests go out or certain operations are allowed based on network status.

### Testing

* Offline support is probably best tested using an Android emulator. Airplane mode on the device can be used to force the app into an offline state. I would recommend pointing to the dev `nmdc-server` instance, though, because even in airplane mode the device knows it can make local (e.g. `127.0.0.1`) requests. A web browser's dev tools can also simulate offline conditions but you _cannot_ test starting the app in an offline state that way.
* To test the API error messages (while online) I used my local `nmdc-server` instance and have it unconditionally raise exceptions in specific request handler functions (i.e. in `nmdc_server/api.py`). Sometimes I would also intentionally add delays in order to verify the transitions between loading and error states. So for example:
```python
@router.get(
    "/metadata_submission",
    tags=["metadata_submission"],
    responses=login_required_responses,
    response_model=query.MetadataSubmissionResponse,
)
async def list_submissions(
    db: Session = Depends(get_db),
    user: models.User = Depends(get_current_user),
    pagination: Pagination = Depends(),
):
    query = crud.get_submissions_for_user(db, user)
    time.sleep(2)
    raise HTTPException(status_code=410, detail="whoops")
    return pagination.response(query)
```