### PR TITLE
Fix 'Guide' dark mode issue

### DIFF
--- a/src/components/Checklist/Checklist.module.css
+++ b/src/components/Checklist/Checklist.module.css
@@ -5,7 +5,6 @@
 }
 
 .listItem {
-  color: black;
   a {
     text-decoration: none;
   }


### PR DESCRIPTION
Update .listItem in Checklist.module.css: remove 'color: black'
