### PR TITLE
Rework release process to account for version and build numbers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,3 +16,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Create Release
         uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -232,11 +232,11 @@ Here's how you can introduce a new environment variable to the code base:
 
 ### Make a release
 
-Creating a release involves three steps: 
+Creating a release involves three steps:
 
-* Increment the build number and optionally update the version number
-* Create and distribute a new Android build
-* Create and distribute a new iOS build
+- Increment the build number and optionally update the version number
+- Create and distribute a new Android build
+- Create and distribute a new iOS build
 
 #### Incrementing build and version numbers
 
@@ -245,8 +245,8 @@ Creating a release involves three steps:
 <details>
 <summary>How do I choose?</summary>
 
-* A build release is a new **testing** release of the app. It may be thought of as a release candidate. It implies a new `buildNumber` in `package.json`. This corresponds to a new "build number" in [iOS terms](https://help.apple.com/xcode/mac/current/#/devba7f53ad4) or "versionCode" in [Android terms](https://developer.android.com/studio/publish/versioning). New builds do not go through Apple's approval process when released to TestFlight.
-* A version release is a new **general** release of the app. It implies a new `version` number in `package.json` _and_ new `buildNumber`. The commit where these numbers are updated is also tagged. The new `version` corresponds to a new "version number" in [iOS terms](https://help.apple.com/xcode/mac/current/#/devba7f53ad4) or "versionName" in [Android terms](https://developer.android.com/studio/publish/versioning). There will typically be several build releases before a version release.
+- A build release is a new **testing** release of the app. It may be thought of as a release candidate. It implies a new `buildNumber` in `package.json`. This corresponds to a new "build number" in [iOS terms](https://help.apple.com/xcode/mac/current/#/devba7f53ad4) or "versionCode" in [Android terms](https://developer.android.com/studio/publish/versioning). New builds do not go through Apple's approval process when released to TestFlight.
+- A version release is a new **general** release of the app. It implies a new `version` number in `package.json` _and_ new `buildNumber`. The commit where these numbers are updated is also tagged. The new `version` corresponds to a new "version number" in [iOS terms](https://help.apple.com/xcode/mac/current/#/devba7f53ad4) or "versionName" in [Android terms](https://developer.android.com/studio/publish/versioning). There will typically be several build releases before a version release.
 
 </details>
 
@@ -305,7 +305,7 @@ Creating a release involves three steps:
 2. Distribute the APK file via the GitHub Release.
    1. Make a copy of the APK file with the version and build numbers in the filename.
       ```shell
-      npm run rename.apk 
+      npm run rename.apk
       ```
    2. Edit the vX.Y.Z [GitHub Release](https://github.com/microbiomedata/nmdc-field-notes/releases) and attach the `org.microbiomedata.fieldnotes-vX.Y.Z-build.N.apk` file to it. **NOTE**: If this is a **build** release there may be one or more existing APK files attached to the release. This is expected.
    3. Deleted the APK file from your local project root.

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Creating a release involves three steps:
 <details>
 <summary>How do I choose?</summary>
 
-- A build release is a new **testing** release of the app. It may be thought of as a release candidate. It implies a new `buildNumber` in `package.json`. This corresponds to a new "build number" in [iOS terms](https://help.apple.com/xcode/mac/current/#/devba7f53ad4) or "versionCode" in [Android terms](https://developer.android.com/studio/publish/versioning). New builds do not go through Apple's approval process when released to TestFlight.
+- A build release is a new **testing** release of the app. It may be thought of as a release candidate. It implies a new `buildNumber` in `package.json`. This corresponds to a new "build number" in [iOS terms](https://help.apple.com/xcode/mac/current/#/devba7f53ad4) or "versionCode" in [Android terms](https://developer.android.com/studio/publish/versioning). New builds (of already-released _versions_) do not go through Apple's approval process when released to TestFlight.
 - A version release is a new **general** release of the app. It implies a new `version` number in `package.json` _and_ new `buildNumber`. The commit where these numbers are updated is also tagged. The new `version` corresponds to a new "version number" in [iOS terms](https://help.apple.com/xcode/mac/current/#/devba7f53ad4) or "versionName" in [Android terms](https://developer.android.com/studio/publish/versioning). There will typically be several build releases before a version release.
 
 </details>
@@ -307,7 +307,7 @@ Creating a release involves three steps:
       ```shell
       npm run rename.apk
       ```
-   2. Edit the vX.Y.Z [GitHub Release](https://github.com/microbiomedata/nmdc-field-notes/releases) and attach the `org.microbiomedata.fieldnotes-vX.Y.Z-build.N.apk` file to it. **NOTE**: If this is a **build** release there may be one or more existing APK files attached to the release. This is expected.
+   2. Edit the vX.Y.Z [GitHub Release](https://github.com/microbiomedata/nmdc-field-notes/releases) and attach the `org.microbiomedata.fieldnotes-vX.Y.Z-build.N.apk` file to it. **NOTE**: If this is a **build** release there may be one or more existing APK files attached to the release. This is by design.
    3. Deleted the APK file from your local project root.
       ```shell
       rm org.microbiomedata.fieldnotes-*.apk

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Creating a release involves three steps:
 <details>
 <summary>How do I choose?</summary>
 
-* A build release is a new **internal** release of the app. It may be thought of as a release candidate. It implies a new `buildNumber` in `package.json`. This corresponds to a new "build number" in [iOS terms](https://help.apple.com/xcode/mac/current/#/devba7f53ad4) or "versionCode" in [Android terms](https://developer.android.com/studio/publish/versioning). New builds do not go through Apple's approval process when released to TestFlight.
+* A build release is a new **testing** release of the app. It may be thought of as a release candidate. It implies a new `buildNumber` in `package.json`. This corresponds to a new "build number" in [iOS terms](https://help.apple.com/xcode/mac/current/#/devba7f53ad4) or "versionCode" in [Android terms](https://developer.android.com/studio/publish/versioning). New builds do not go through Apple's approval process when released to TestFlight.
 * A version release is a new **general** release of the app. It implies a new `version` number in `package.json` _and_ new `buildNumber`. The commit where these numbers are updated is also tagged. The new `version` corresponds to a new "version number" in [iOS terms](https://help.apple.com/xcode/mac/current/#/devba7f53ad4) or "versionName" in [Android terms](https://developer.android.com/studio/publish/versioning). There will typically be several build releases before a version release.
 
 </details>
@@ -265,7 +265,6 @@ Creating a release involves three steps:
       npm run release -- patch  # (or "minor" or "major")
       git push --follow-tags
       ```
-
 3. If this is a **version** release, check [GitHub Actions](https://github.com/microbiomedata/nmdc-field-notes/actions) to ensure that pushing the version tag triggered the workflow that creates a new GitHub Release. Ensure that the workflow completed successfully.
 
 #### Create and Distribute a new Android Build
@@ -309,7 +308,7 @@ Creating a release involves three steps:
       npm run rename.apk 
       ```
    2. Edit the vX.Y.Z [GitHub Release](https://github.com/microbiomedata/nmdc-field-notes/releases) and attach the `org.microbiomedata.fieldnotes-vX.Y.Z-build.N.apk` file to it. **NOTE**: If this is a **build** release there may be one or more existing APK files attached to the release. This is expected.
-   3. The APK file can now be deleted from your local project root.
+   3. Deleted the APK file from your local project root.
       ```shell
       rm org.microbiomedata.fieldnotes-*.apk
       ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,6 @@
         "terser": "^5.4.0",
         "typescript": "^5.1.6",
         "vite": "^5.0.0",
-        "vite-plugin-package-version": "^1.1.0",
         "vitest": "^0.34.6"
       },
       "optionalDependencies": {
@@ -20768,14 +20767,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite-plugin-package-version": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "vite": ">=2.0.0-beta.69"
       }
     },
     "node_modules/vite/node_modules/@esbuild/darwin-x64": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "terser": "^5.4.0",
     "typescript": "^5.1.6",
     "vite": "^5.0.0",
-    "vite-plugin-package-version": "^1.1.0",
     "vitest": "^0.34.6"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "nmdc-field-notes",
   "private": true,
   "version": "0.1.0",
+  "config": {
+    "buildNumber": 4
+  },
   "type": "module",
   "scripts": {
     "dev": "ionic serve --host=127.0.0.1 --port=8100 --no-open",
@@ -18,8 +21,8 @@
     "lint": "eslint src",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "preversion": "vitest run",
-    "version": "APP_VERSION=$npm_package_version trapeze run trapeze.config.yaml -y && git add android ios"
+    "prerelease": "vitest run && npm run build.native",
+    "release": "./scripts/release.sh"
   },
   "dependencies": {
     "@capacitor/android": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "ionic serve --host=127.0.0.1 --port=8100 --no-open",
-    "build": "tsc && vite build",
+    "build": "tsc && ionic build",
+    "build.native": "tsc && ionic capacitor sync",
     "format": "prettier . --write",
     "check.format": "prettier . --check",
     "check.imports": "madge --circular src/main.tsx",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "prerelease": "vitest run && npm run build.native",
-    "release": "./scripts/release.sh"
+    "release": "./scripts/release.sh",
+    "rename.apk": "cp android/app/release/app-release.apk org.microbiomedata.fieldnotes-v$npm_package_version-build.$npm_package_config_buildNumber.apk"
   },
   "dependencies": {
     "@capacitor/android": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "scripts": {
     "dev": "ionic serve --host=127.0.0.1 --port=8100 --no-open",
-    "build": "tsc && ionic build",
+    "build": "tsc && vite build",
     "build.native": "tsc && ionic capacitor sync",
     "format": "prettier . --write",
     "check.format": "prettier . --check",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,6 +6,7 @@ log() {
   echo "[release] $1"
 }
 
+# Validate the first CLI option passed to the script.
 if [[ ! $1 =~ ^(major|minor|patch|build)$ ]]; then
   log "ERROR: Must specify a release type: major, minor, patch, or build"
   exit 1
@@ -32,7 +33,7 @@ npm pkg set config.buildNumber=$NEW_BUILD_NUMBER --json
 
 log "New build number: $NEW_BUILD_NUMBER"
 
-# If this is a build release grab the existing version number, otherwise increment the version
+# If this is a build release, grab the existing version number; otherwise, increment the version
 # number by running 'npm version' and then grab the new version number.
 if [[ "$RELEASE_TYPE" == "build" ]]; then
   VERSION_NUMBER=${npm_package_version:=}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -e
+
+log() {
+  echo "[release] $1"
+}
+
+if [[ ! $1 =~ ^(major|minor|patch|build)$ ]]; then
+  log "ERROR: Must specify a release type: major, minor, patch, or build"
+  exit 1
+fi
+
+RELEASE_TYPE=$1
+
+log "Checking for clean working directory"
+#if [[ -n "$(git status --porcelain)" ]]; then
+#  log "ERROR: Working directory must be clean. Stash or commit changes before releasing."
+#  exit 1
+#fi
+
+# Increment the build number by getting the current build number from the package.json file,
+# incrementing it by 1, and then setting the new build number in the package.json file.
+CURRENT_BUILD_NUMBER=${npm_package_config_buildNumber:=}
+if [[ -z $CURRENT_BUILD_NUMBER ]]; then
+  log "ERROR: Cannot determine current build number from package.json"
+  log "       Ensure that release.sh is being called via 'npm run release' and not directly"
+  exit 1
+fi
+NEW_BUILD_NUMBER=$((CURRENT_BUILD_NUMBER + 1))
+npm pkg set config.buildNumber=$NEW_BUILD_NUMBER --json
+
+log "New build number: $NEW_BUILD_NUMBER"
+
+# If this is a build release grab the existing version number, otherwise increment the version
+# number by running 'npm version' and then grab the new version number.
+if [[ "$RELEASE_TYPE" == "build" ]]; then
+  VERSION_NUMBER=${npm_package_version:=}
+  if [[ -z $VERSION_NUMBER ]]; then
+    log "ERROR: Cannot determine current version number from package.json"
+    log "       Ensure that release.sh is being called via 'npm run release' and not directly"
+    exit 1
+  fi
+  log "Keeping existing version number: $VERSION_NUMBER"
+else
+  VERSION_NUMBER=$(npm version "$RELEASE_TYPE" --no-git-tag-version)
+  VERSION_NUMBER=${VERSION_NUMBER:1}  # Remove the 'v' prefix
+  log "New version number: $VERSION_NUMBER"
+fi
+
+# Run trapeze to propagate the new version and build number to native projects
+log "Updating native projects"
+export FIELD_NOTES_VERSION_NUMBER=$VERSION_NUMBER
+export FIELD_NOTES_BUILD_NUMBER=$NEW_BUILD_NUMBER
+trapeze run trapeze.config.yaml -y
+
+# Commit the changes to package.json, package-lock.json, and native projects
+COMMIT_MESSAGE="$VERSION_NUMBER ($NEW_BUILD_NUMBER)"
+log "Creating commit: $COMMIT_MESSAGE"
+git add package.json package-lock.json android ios
+echo "git commit -m \"$COMMIT_MESSAGE\""
+
+# If this is not a build release, tag the commit with the new version number
+if [[ "$RELEASE_TYPE" != "build" ]]; then
+  TAG_MESSAGE="v$VERSION_NUMBER"
+  log "Creating tag: $TAG_MESSAGE"
+  echo "git tag -a \"$TAG_MESSAGE\" -m \"$TAG_MESSAGE\""
+fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -14,10 +14,10 @@ fi
 RELEASE_TYPE=$1
 
 log "Checking for clean working directory"
-#if [[ -n "$(git status --porcelain)" ]]; then
-#  log "ERROR: Working directory must be clean. Stash or commit changes before releasing."
-#  exit 1
-#fi
+if [[ -n "$(git status --porcelain)" ]]; then
+  log "ERROR: Working directory must be clean. Stash or commit changes before releasing."
+  exit 1
+fi
 
 # Increment the build number by getting the current build number from the package.json file,
 # incrementing it by 1, and then setting the new build number in the package.json file.
@@ -58,11 +58,11 @@ trapeze run trapeze.config.yaml -y
 COMMIT_MESSAGE="$VERSION_NUMBER ($NEW_BUILD_NUMBER)"
 log "Creating commit: $COMMIT_MESSAGE"
 git add package.json package-lock.json android ios
-echo "git commit -m \"$COMMIT_MESSAGE\""
+git commit -m "$COMMIT_MESSAGE"
 
 # If this is not a build release, tag the commit with the new version number
 if [[ "$RELEASE_TYPE" != "build" ]]; then
   TAG_MESSAGE="v$VERSION_NUMBER"
   log "Creating tag: $TAG_MESSAGE"
-  echo "git tag -a \"$TAG_MESSAGE\" -m \"$TAG_MESSAGE\""
+  git tag -a "$TAG_MESSAGE" -m "$TAG_MESSAGE"
 fi

--- a/src/components/SettingsAboutList/SettingsAboutList.tsx
+++ b/src/components/SettingsAboutList/SettingsAboutList.tsx
@@ -8,7 +8,9 @@ const SettingsAboutList: React.FC = () => {
       <IonItem>
         <IonLabel>
           <h3>Version</h3>
-          <p>{config.APP_VERSION}</p>
+          <p>
+            {config.APP_VERSION} ({config.APP_BUILD})
+          </p>
         </IonLabel>
       </IonItem>
     </IonList>

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,8 @@
 const env = import.meta.env;
 
 interface Config {
-  APP_VERSION: typeof env.PACKAGE_VERSION;
+  APP_VERSION: typeof env.FIELD_NOTES_VERSION_NUMBER;
+  APP_BUILD: typeof env.FIELD_NOTES_BUILD_NUMBER;
   NMDC_SERVER_API_URL: string;
   SUPPORT_EMAIL: string;
 }
@@ -22,9 +23,20 @@ const config: Config = {
   /**
    * Version identifier of the app (e.g. "1.23.456").
    *
-   * This is the value of the `version` property in the `package.json` file.
+   * This is the value of the `version` property in the `package.json` file. However, it
+   * is only set when initiated by an NPM script (i.e. `npm run <script>`). If you are not
+   * seeing the correct value, confirm that you are using an NPM script.
    */
-  APP_VERSION: env.PACKAGE_VERSION,
+  APP_VERSION: env.FIELD_NOTES_VERSION_NUMBER || "0.0.0",
+
+  /**
+   * Build identifier of the app (e.g. "4").
+   *
+   * This is the value of the `config.buildNumber` property in the `package.json` file.
+   * However, it is only set when initiated by an NPM script (i.e. `npm run <script>`). If you
+   * are not seeing the correct value, confirm that you are using an NPM script.
+   */
+  APP_BUILD: env.FIELD_NOTES_BUILD_NUMBER || "0",
 
   /**
    * URL of the endpoint the mobile app can use to access the NMDC data portal API.

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -9,7 +9,8 @@
 interface ImportMetaEnv {
   readonly VITE_NMDC_SERVER_API_URL?: string;
   readonly VITE_NMDC_SERVER_LOGIN_URL?: string;
-  readonly PACKAGE_VERSION: string;
+  readonly FIELD_NOTES_BUILD_NUMBER: string;
+  readonly FIELD_NOTES_VERSION_NUMBER: string;
 }
 
 /**

--- a/trapeze.config.yaml
+++ b/trapeze.config.yaml
@@ -1,13 +1,13 @@
 vars:
-  APP_VERSION:
-    default: 0.0.0
+  FIELD_NOTES_VERSION_NUMBER:
+  FIELD_NOTES_BUILD_NUMBER:
 
 platforms:
   android:
-    incrementVersionCode: true
-    versionName: $APP_VERSION
+    versionCode: $FIELD_NOTES_BUILD_NUMBER
+    versionName: $FIELD_NOTES_VERSION_NUMBER
   ios:
     targets:
       App:
-        incrementBuild: true
-        version: $APP_VERSION
+        buildNumber: $FIELD_NOTES_BUILD_NUMBER
+        version: $FIELD_NOTES_VERSION_NUMBER

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,24 +1,28 @@
 /// <reference types="vitest" />
 import legacy from "@vitejs/plugin-legacy";
 import react from "@vitejs/plugin-react";
-import packageVersion from "vite-plugin-package-version";
 import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [
-    react(),
-    legacy(),
-    /**
-     * Note: The `packageVersion()` plugin reads the `version` value from `package.json`
-     *       and makes it available to the app via `import.meta.env.PACKAGE_VERSION`.
-     *       Reference: https://www.npmjs.com/package/vite-plugin-package-version
-     */
-    packageVersion(),
-  ],
+  plugins: [react(), legacy()],
   test: {
     globals: true,
     environment: "jsdom",
     setupFiles: "./src/setupTests.ts",
+  },
+  define: {
+    // This makes the `version` value from `package.json` available to the app
+    // as `import.meta.env.FIELD_NOTES_VERSION_NUMBER`. This only works when
+    // invoked by an NPM script (i.e. `npm run <script>`).
+    "import.meta.env.FIELD_NOTES_VERSION_NUMBER": JSON.stringify(
+      process.env.npm_package_version,
+    ),
+    // This makes the `config.buildNumber` value from `package.json` available to
+    // the app as `import.meta.env.FIELD_NOTES_BUILD_NUMBER`. This only works when
+    // invoked by an NPM script (i.e. `npm run <script>`).
+    "import.meta.env.FIELD_NOTES_BUILD_NUMBER": JSON.stringify(
+      process.env.npm_package_config_buildNumber,
+    ),
   },
 });


### PR DESCRIPTION
Fixes #159 

As mentioned [here](https://github.com/microbiomedata/nmdc-field-notes/issues/159#issuecomment-2302571188) the proximate cause of the version number not appearing in the Settings tab was that we were implicitly relying on an environment variable only set when running NPM scripts. And the release instructions were written to _not_ use NPM scripts.

Another wrinkle is that the release instructions were mainly focused on the _version_ number. But we learned in our first go at following the instructions in earnest that the _build_ number is also an important consideration. Sometimes we will _only_ want to increment the build number without updating the version number.

### Summary

* Previously the source of truth for the build number was _two_ native project files (`android/app/build.gradle` and `ios/App/App.xcodeproj/project.pbxproj`). We used Trapeze's ability to increment those values. With these changes the build number source of truth is a [config parameter](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#config) (named `buildNumber`) in `package.json`. I think this has the advantages of:
  * A single source of truth
  * More control over when the value is incremented
  * Access to this value in other parts of our build process since it is exported as an environment variable
* Previously we used `vite-plugin-package-version` to inject the `version` from `package.json` into  `import.meta.env.PACKAGE_VERSION`. With these changes I've removed the plugin and updated `vite.config.ts` to do essentially the same thing that the plugin was doing (except that it injects into `import.meta.env.FIELD_NOTES_VERSION_NUMBER`). This makes the dependence on the `$npm_package_version` environment variable more explicit and allows injecting the build number as well. [See also](https://vitejs.dev/config/shared-options.html#define).
* The new `import.meta.env` keys are fished through various parts of the application code, and _both_ are now displayed in the Settings tab in Apple-ish `version (build)` format.
* Previously the release process was based around running `npm version`. This precludes the case where we _only_ want to change the build number. The changes here add a new file (`scripts/release.sh`) to orchestrate the process, including:
  * Incrementing the build number
  * Optionally updating the version number
  * Calling Trapeze to propagate the new numbers into native projects (Trapeze now simply takes the build number that it's given instead of incrementing it itself)
  * Committing the changed files
  * Optionally tagging the commit
  
  Having this as a dedicated script feels way more maintainable to me than a nest of interrelated NPM scripts. Although it's still important to _invoke_ it via the new `release` NPM script so that the necessary environment variables are set. If it is possible to automate more of the native project build processes I could imagine expanding this script to include that in the future.
* The release instructions in `README.md` have been updated:
  * Removing a few unnecessary steps
  * Emphasizing the distinction between a new build vs a new version
  * Referring to the new commands/scripts
* Updated the GitHub workflow that creates new releases to automatically generate release notes.