### PR TITLE
Schema fetching and caching

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { IonApp, setupIonicReact } from "@ionic/react";
 import ColorSchemePreferenceMonitor from "./components/ColorSchemePreferenceMonitor/ColorSchemePreferenceMonitor";
+import DataPrefetcher from "./components/DataPrefetcher/DataPrefetcher";
 import QueryClientProvider from "./QueryClientProvider";
 import NetworkStatusProvider from "./NetworkStatus";
 import Router from "./Router";
@@ -50,6 +51,7 @@ const App: React.FC = () => {
         <QueryClientProvider>
           <IonApp>
             <ColorSchemePreferenceMonitor />
+            <DataPrefetcher />
             <Router />
           </IonApp>
         </QueryClientProvider>

--- a/src/api.ts
+++ b/src/api.ts
@@ -220,6 +220,12 @@ export interface LockOperationResult {
   lock_updated?: string | null; // ISO 8601 datetime string
 }
 
+export interface VersionInfo {
+  nmdc_server: string;
+  nmdc_schema: string;
+  nmdc_submission_schema: string;
+}
+
 export class ApiError extends Error {
   public readonly request: Request;
   public readonly response: Response;
@@ -407,6 +413,10 @@ class NmdcServerClient extends FetchClient {
     return this.fetchJson<GoldEcosystemTreeNode>(
       "/static/submission_schema/GoldEcosystemTree.json",
     );
+  }
+
+  async getVersionInfo() {
+    return this.fetchJson<VersionInfo>("/api/version");
   }
 
   // This method is rate-limited to once every 20 seconds. This is because it's possible for

--- a/src/components/DataPrefetcher/DataPrefetcher.tsx
+++ b/src/components/DataPrefetcher/DataPrefetcher.tsx
@@ -1,13 +1,18 @@
 import { useEffect } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useIsRestoring, useQueryClient } from "@tanstack/react-query";
 import { prefetchSubmissionSchema } from "../../queries";
 
 const DataPrefetcher = () => {
   const queryClient = useQueryClient();
+  const isRestoring = useIsRestoring();
 
   useEffect(() => {
-    void prefetchSubmissionSchema(queryClient);
-  }, [queryClient]);
+    // Since this prefetch relies on checking cached data, don't do it until the initial persisted
+    // cache has been restored.
+    if (!isRestoring) {
+      void prefetchSubmissionSchema(queryClient);
+    }
+  }, [queryClient, isRestoring]);
 
   return null;
 };

--- a/src/components/DataPrefetcher/DataPrefetcher.tsx
+++ b/src/components/DataPrefetcher/DataPrefetcher.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { prefetchSubmissionSchema } from "../../queries";
+
+const DataPrefetcher = () => {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    void prefetchSubmissionSchema(queryClient);
+  }, [queryClient]);
+
+  return null;
+};
+
+export default DataPrefetcher;

--- a/src/pages/SamplePage/SamplePage.tsx
+++ b/src/pages/SamplePage/SamplePage.tsx
@@ -247,6 +247,14 @@ const SamplePage: React.FC = () => {
             </Banner>
           )}
 
+        {!schema.data && !schema.isFetching && (
+          <Banner color="danger">
+            <IonLabel>
+              <b>Error</b> Missing schema information
+            </IonLabel>
+          </Banner>
+        )}
+
         {schema.data && (
           <>
             <SampleView

--- a/src/pages/SamplePage/SamplePage.tsx
+++ b/src/pages/SamplePage/SamplePage.tsx
@@ -250,7 +250,8 @@ const SamplePage: React.FC = () => {
         {!schema.data && !schema.isFetching && (
           <Banner color="danger">
             <IonLabel>
-              <b>Error</b> Schema not found. Please ensure you are connected to the internet and try again.
+              <b>Error</b> Schema not found. Please ensure you are connected to
+              the internet and try again.
             </IonLabel>
           </Banner>
         )}

--- a/src/pages/SamplePage/SamplePage.tsx
+++ b/src/pages/SamplePage/SamplePage.tsx
@@ -250,7 +250,7 @@ const SamplePage: React.FC = () => {
         {!schema.data && !schema.isFetching && (
           <Banner color="danger">
             <IonLabel>
-              <b>Error</b> Missing schema information
+              <b>Error</b> Schema not found. Please ensure you are connected to the internet and try again.
             </IonLabel>
           </Banner>
         )}

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -3,6 +3,7 @@ import {
   hashKey,
   InfiniteData,
   QueryClient,
+  queryOptions,
   useInfiniteQuery,
   useMutation,
   useQuery,
@@ -31,8 +32,11 @@ export const submissionKeys = {
   lock: (id: string) => [...submissionKeys.locks(), id],
   unlocks: () => [...submissionKeys.all(), "unlock"],
   unlock: (id: string) => [...submissionKeys.unlocks(), id],
-  schemas: () => ["schemas"],
-  submissionSchema: () => [...submissionKeys.schemas(), "submission_schema"],
+};
+
+export const schemaKeys = {
+  all: () => ["schemas"],
+  submissionSchema: () => [...schemaKeys.all(), "submission_schema"],
 };
 
 export function addDefaultMutationFns(queryClient: QueryClient) {
@@ -308,9 +312,11 @@ export function useSubmissionCreate() {
   return mutation;
 }
 
-export function useSubmissionSchema() {
-  return useQuery({
-    queryKey: submissionKeys.submissionSchema(),
+function submissionSchemaQueryOptions() {
+  // The `queryOptions` function is to help with type inference
+  // https://tanstack.com/query/latest/docs/framework/react/typescript#typing-query-options
+  return queryOptions({
+    queryKey: schemaKeys.submissionSchema(),
     // These two files are used in conjunction with each other so make the two requests in parallel
     // and return an object bundling the results together.
     queryFn: async () => {
@@ -325,4 +331,14 @@ export function useSubmissionSchema() {
     },
     staleTime: 1000 * 60 * 60 * 72, // 72 hours; these files only change between releases
   });
+}
+export function useSubmissionSchema() {
+  return useQuery(submissionSchemaQueryOptions());
+}
+// NOTE: this is a plain function, not a hook!
+// See:
+// - https://tanstack.com/query/v5/docs/framework/react/guides/prefetching
+// - https://tanstack.com/query/v5/docs/reference/QueryClient/#queryclientprefetchquery
+export function prefetchSubmissionSchema(queryClient: QueryClient) {
+  return queryClient.prefetchQuery(submissionSchemaQueryOptions());
 }

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -17,8 +17,10 @@ import {
   LockOperationResult,
   ApiError,
   SubmissionMetadataUpdate,
+  GoldEcosystemTreeNode,
 } from "./api";
 import { produce } from "immer";
+import { SchemaDefinition } from "./linkml-metamodel";
 
 export const submissionKeys = {
   all: () => ["submissions"],
@@ -312,7 +314,11 @@ export function useSubmissionCreate() {
   return mutation;
 }
 
-function submissionSchemaQueryOptions() {
+export interface SubmissionSchema {
+  schema: SchemaDefinition;
+  goldEcosystemTree: GoldEcosystemTreeNode;
+}
+function submissionSchemaQueryOptions(queryClient: QueryClient) {
   // The `queryOptions` function is to help with type inference
   // https://tanstack.com/query/latest/docs/framework/react/typescript#typing-query-options
   return queryOptions({
@@ -320,6 +326,19 @@ function submissionSchemaQueryOptions() {
     // These two files are used in conjunction with each other so make the two requests in parallel
     // and return an object bundling the results together.
     queryFn: async () => {
+      const cachedData = queryClient.getQueryData<SubmissionSchema>(
+        schemaKeys.submissionSchema(),
+      );
+      if (cachedData !== undefined) {
+        // We have a copy of the schema in the cache. Check to see if it is still the latest version
+        const versionInfo = await nmdcServerClient.getVersionInfo();
+        // If the cached schema is the same version as the current server version, return the cached
+        // schema
+        if (cachedData.schema.version === versionInfo.nmdc_submission_schema) {
+          return cachedData;
+        }
+      }
+      // We don't have a cached schema or the cached schema is out of date. Fetch the latest schema.
       const result = await Promise.all([
         nmdcServerClient.getSubmissionSchema(),
         nmdcServerClient.getGoldEcosystemTree(),
@@ -329,16 +348,20 @@ function submissionSchemaQueryOptions() {
         goldEcosystemTree: result[1],
       };
     },
-    staleTime: 1000 * 60 * 60 * 72, // 72 hours; these files only change between releases
+    // Nearly all the time the queryFn will only result in a version info check. This is a pretty
+    // inexpensive call, but we still don't need to do it that often. Let's try no more than once
+    // every 30 minutes.
+    staleTime: 1000 * 60 * 30,
   });
 }
 export function useSubmissionSchema() {
-  return useQuery(submissionSchemaQueryOptions());
+  const queryClient = useQueryClient();
+  return useQuery(submissionSchemaQueryOptions(queryClient));
 }
 // NOTE: this is a plain function, not a hook!
 // See:
 // - https://tanstack.com/query/v5/docs/framework/react/guides/prefetching
 // - https://tanstack.com/query/v5/docs/reference/QueryClient/#queryclientprefetchquery
 export function prefetchSubmissionSchema(queryClient: QueryClient) {
-  return queryClient.prefetchQuery(submissionSchemaQueryOptions());
+  return queryClient.prefetchQuery(submissionSchemaQueryOptions(queryClient));
 }

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -329,11 +329,10 @@ function submissionSchemaQueryOptions(queryClient: QueryClient) {
       const cachedData = queryClient.getQueryData<SubmissionSchema>(
         schemaKeys.submissionSchema(),
       );
+      // If we have a cached schema and it's the same version as the server
+      // would give us if we were to fetch it now, return that cached schema.
       if (cachedData !== undefined) {
-        // We have a copy of the schema in the cache. Check to see if it is still the latest version
         const versionInfo = await nmdcServerClient.getVersionInfo();
-        // If the cached schema is the same version as the current server version, return the cached
-        // schema
         if (cachedData.schema.version === versionInfo.nmdc_submission_schema) {
           return cachedData;
         }


### PR DESCRIPTION
Fixes #155 
Fixes #156 

### Summary

These changes fix two related issues around when and how the submission schema is fetched. The goals are:

* Prefetch the schema _before_ it is needed to prevent certain bad situations while offline. In the event that the schema is still not available when it is needed, show an error message.
* Only fetch the schema when a new version is available.

### Details

Previously the schema information was fetched at the time it was needed via the `useSubmissionSchema` hook call in the `SamplePage` component. The hook is still called there, but now the data it provides is prefetched via a new `DataPrefetcher` component placed near the top-level of the app. See the [TanStack Query docs](https://tanstack.com/query/v5/docs/framework/react/guides/prefetching) for details on their recommended prefetching approaches. 

Assuming that prefetch happened successfully at least once when opening the app online, then the cached prefetched data will be returned by the `useSubmissionSchema` hook while using the app later, even while offline. In the event that _all_ of that somehow goes wrong and the `SamplePage` component ends up with no submission schema information, it will now show an error message instead of a blank page.

Previously the submission schema query had a long `staleTime` (72 hours) in an attempt to not download the two schema files too often (they are somewhat large). This had the downside of not getting an updated schema after a new release for several days. With these changes the submission schema `queryFn` first checks to see if its cached version matches the server's version (via the `/api/version` endpoint). If it does then no further fetching is done, and the cached version is returned. Otherwise (no cached version or mismatched versions) a fetch for the schema files is done.

### Testing

These changes are tricky to test! Following the steps in #155 is a good start. For testing #166, I verified by downgrading my local `nmdc-server` stack to `nmdc-submission-schema` version 10.7.0, using the app, upgrading back to 10.8.0, and verifying that reloading the app caused a redownload of the schema.


