### PR TITLE
Generate template list (Markdown) from the existing `TEMPLATES` object

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,1 +1,2 @@
 VITE_NMDC_SERVER_API_URL=http://127.0.0.1:8000
+VITE_NMDC_SUBMISSION_SCHEMA_DOCS_BASE_URL=https://microbiomedata.github.io/submission-schema

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
 VITE_NMDC_SERVER_API_URL=https://data.microbiomedata.org
+VITE_NMDC_SUBMISSION_SCHEMA_DOCS_BASE_URL=https://microbiomedata.github.io/submission-schema

--- a/.env.staging
+++ b/.env.staging
@@ -1,1 +1,2 @@
 VITE_NMDC_SERVER_API_URL=https://data-dev.microbiomedata.org
+VITE_NMDC_SUBMISSION_SCHEMA_DOCS_BASE_URL=https://microbiomedata.github.io/submission-schema

--- a/src/components/Checklist/md-in-js/fieldwork-003.md.ts
+++ b/src/components/Checklist/md-in-js/fieldwork-003.md.ts
@@ -6,7 +6,7 @@ Schema for biosamples based on MIxS and other standards
 `;
 
 // Generate schemas Markdown from the TEMPLATES
-import {createSchemasMD} from './util';
+import { createSchemasMD } from './util';
 const rawMarkdownContent = createSchemasMD();
 
 export const markdownContent = rawMarkdownContent.trim();

--- a/src/components/Checklist/md-in-js/fieldwork-003.md.ts
+++ b/src/components/Checklist/md-in-js/fieldwork-003.md.ts
@@ -6,7 +6,7 @@ Schema for biosamples based on MIxS and other standards
 `;
 
 // Generate schemas Markdown from the TEMPLATES
-import { createSchemasMD } from './util';
+import { createSchemasMD } from "./util";
 const rawMarkdownContent = createSchemasMD();
 
 export const markdownContent = rawMarkdownContent.trim();

--- a/src/components/Checklist/md-in-js/fieldwork-003.md.ts
+++ b/src/components/Checklist/md-in-js/fieldwork-003.md.ts
@@ -4,19 +4,10 @@ export const title = `Review relevant NMDC environment schemas`;
 export const info = `
 Schema for biosamples based on MIxS and other standards
 `;
-// Mark nested list item with 'NESTEDLISTITEM'
-const rawMarkdownContent = `
-* [air](https://microbiomedata.github.io/submission-schema/AirInterface/)
-* [built environment](https://microbiomedata.github.io/submission-schema/BuiltEnvInterface/)
-* [host-associated](https://microbiomedata.github.io/submission-schema/HostAssociatedInterface/)
-* [hydrocarbon resources - cores](https://microbiomedata.github.io/submission-schema/HcrCoresInterface/)
-* [hydrocarbon resources - fluids swabs](https://microbiomedata.github.io/submission-schema/HcrFluidsSwabsInterface/)
-* [microbial mat_biofilm](https://microbiomedata.github.io/submission-schema/BiofilmInterface/)
-* [miscellaneous natural or artificial environment](https://microbiomedata.github.io/submission-schema/MiscEnvsInterface/)
-* [plant-associated](https://microbiomedata.github.io/submission-schema/PlantAssociatedInterface/)
-* [sediment](https://microbiomedata.github.io/submission-schema/SedimentInterface/)
-* [soil](https://microbiomedata.github.io/submission-schema/SoilInterface/)
-`;
+
+// Generate schemas Markdown from the TEMPLATES
+import {createSchemasMD} from './util';
+const rawMarkdownContent = createSchemasMD();
 
 export const markdownContent = rawMarkdownContent.trim();
 

--- a/src/components/Checklist/md-in-js/fieldwork-003.md.ts
+++ b/src/components/Checklist/md-in-js/fieldwork-003.md.ts
@@ -1,3 +1,5 @@
+import { createSchemasMD } from "./util";
+
 export const title = `Review relevant NMDC environment schemas`;
 
 // language=Markdown
@@ -6,7 +8,6 @@ Schema for biosamples based on MIxS and other standards
 `;
 
 // Generate schemas Markdown from the TEMPLATES
-import { createSchemasMD } from "./util";
 const rawMarkdownContent = createSchemasMD();
 
 export const markdownContent = rawMarkdownContent.trim();

--- a/src/components/Checklist/md-in-js/util.tsx
+++ b/src/components/Checklist/md-in-js/util.tsx
@@ -3,12 +3,11 @@ import { TEMPLATES } from "../../../api";
 
 // Generate schemas Markdown from the TEMPLATES
 export function createSchemasMD() {
-  let schemasMD = '';
+  let schemasMD = "";
 
   Object.keys(TEMPLATES).forEach((schema) => {
-    schemasMD += `* [${TEMPLATES[schema].displayName}](${config.NMDC_SCHEMA_BASE_URL}/${TEMPLATES[schema].schemaClass}/)\n`
+    schemasMD += `* [${TEMPLATES[schema].displayName}](${config.NMDC_SUBMISSION_SCHEMA_DOCS_BASE_URL}/${TEMPLATES[schema].schemaClass}/)\n`;
   });
 
   return schemasMD;
 }
-

--- a/src/components/Checklist/md-in-js/util.tsx
+++ b/src/components/Checklist/md-in-js/util.tsx
@@ -1,0 +1,14 @@
+import config from "../../../config";
+import { TEMPLATES } from "../../../api";
+
+// Generate schemas Markdown from the TEMPLATES
+export function createSchemasMD() {
+  let schemasMD = '';
+
+  Object.keys(TEMPLATES).forEach((schema) => {
+    schemasMD += `* [${TEMPLATES[schema].displayName}](${config.NMDC_SCHEMA_BASE_URL}/${TEMPLATES[schema].schemaClass}/)\n`
+  });
+
+  return schemasMD;
+}
+

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,7 +16,7 @@ interface Config {
   APP_VERSION: typeof env.FIELD_NOTES_VERSION_NUMBER;
   APP_BUILD: typeof env.FIELD_NOTES_BUILD_NUMBER;
   NMDC_SERVER_API_URL: string;
-  NMDC_SCHEMA_BASE_URL: string;
+  NMDC_SUBMISSION_SCHEMA_DOCS_BASE_URL: string;
   SHOW_DEV_SITE_WARNING: boolean;
   SUPPORT_EMAIL: string;
 }
@@ -54,7 +54,8 @@ const config: Config = {
    * Default: `https://microbiomedata.github.io/submission-schema`
    */
   NMDC_SUBMISSION_SCHEMA_DOCS_BASE_URL:
-    env.VITE_NMDC_SUBMISSION_SCHEMA_DOCS_BASE_URL || "https://microbiomedata.github.io/submission-schema",
+    env.VITE_NMDC_SUBMISSION_SCHEMA_DOCS_BASE_URL ||
+    "https://microbiomedata.github.io/submission-schema",
 
   /**
    * Whether to show a warning that the user is on a development site.

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ interface Config {
   APP_VERSION: typeof env.FIELD_NOTES_VERSION_NUMBER;
   APP_BUILD: typeof env.FIELD_NOTES_BUILD_NUMBER;
   NMDC_SERVER_API_URL: string;
+  NMDC_SCHEMA_BASE_URL: string;
   SHOW_DEV_SITE_WARNING: boolean;
   SUPPORT_EMAIL: string;
 }
@@ -46,6 +47,14 @@ const config: Config = {
    */
   NMDC_SERVER_API_URL:
     env.VITE_NMDC_SERVER_API_URL || "https://data-dev.microbiomedata.org",
+
+  /**
+   * The base URL of the NMDC submission-schema.
+   *
+   * Default: `https://microbiomedata.github.io/submission-schema`
+   */
+  NMDC_SCHEMA_BASE_URL:
+    env.VITE_NMDC_SCHEMA_BASE_URL || "https://microbiomedata.github.io/submission-schema",
 
   /**
    * Whether to show a warning that the user is on a development site.

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,12 +49,12 @@ const config: Config = {
     env.VITE_NMDC_SERVER_API_URL || "https://data-dev.microbiomedata.org",
 
   /**
-   * The base URL of the NMDC submission-schema.
+   * The base URL of the NMDC submission-schema documentation website.
    *
    * Default: `https://microbiomedata.github.io/submission-schema`
    */
-  NMDC_SCHEMA_BASE_URL:
-    env.VITE_NMDC_SCHEMA_BASE_URL || "https://microbiomedata.github.io/submission-schema",
+  NMDC_SUBMISSION_SCHEMA_DOCS_BASE_URL:
+    env.VITE_NMDC_SUBMISSION_SCHEMA_DOCS_BASE_URL || "https://microbiomedata.github.io/submission-schema",
 
   /**
    * Whether to show a warning that the user is on a development site.

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -9,6 +9,7 @@
 interface ImportMetaEnv {
   readonly VITE_NMDC_SERVER_API_URL?: string;
   readonly VITE_NMDC_SERVER_LOGIN_URL?: string;
+  readonly VITE_NMDC_SUBMISSION_SCHEMA_DOCS_BASE_URL?: string;
   readonly FIELD_NOTES_BUILD_NUMBER: string;
   readonly FIELD_NOTES_VERSION_NUMBER: string;
 }


### PR DESCRIPTION
Generate schemas Markdown from the TEMPLATES instead of hardcoding a list of schemas.