### PR TITLE
Run ionic build after trapeze in release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -49,11 +49,15 @@ else
   log "New version number: $VERSION_NUMBER"
 fi
 
-# Run trapeze to propagate the new version and build number to native projects
+# Run trapeze to propagate the new version and build number to native project files
 log "Updating native projects"
 export FIELD_NOTES_VERSION_NUMBER=$VERSION_NUMBER
 export FIELD_NOTES_BUILD_NUMBER=$NEW_BUILD_NUMBER
 trapeze run trapeze.config.yaml -y
+
+# Rebuild the native projects with the new version and build number
+log "Rebuilding native projects"
+npm run build.native
 
 # Commit the changes to package.json, package-lock.json, and native projects
 COMMIT_MESSAGE="$VERSION_NUMBER ($NEW_BUILD_NUMBER)"


### PR DESCRIPTION
Fixes https://github.com/microbiomedata/nmdc-field-notes/issues/182

As pointed out in the issue, there is a `prerelease` script which runs `npm run build.native` before running the `release.sh` script:

https://github.com/microbiomedata/nmdc-field-notes/blob/d862c821a1a696b0c217b1a55b39d3599108016c/package.json#L24-L25

The purpose of that build is to ensure that we didn't accidentally forget to sync the native projects and commit those changes before making a release (`release.sh` will stop if there are uncommitted changes leftover from that build). We still want to do that, so I've kept that in place.

However, we do need _another_ build _after_ the new build/version numbers are set. This allows the new numbers to be baked into the web assets that the native projects use. I've added that to the `release.sh` script. 

This means that when you run `npm run release` _two_ builds will happen (before _and_ after incrementing the build/version numbers). Maybe not ideal, but I'm not sure I see a way around it. And the builds don't take that long anyway.