### PR TITLE
Add support for multiple environmental templates

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -64,7 +64,10 @@ const Router: React.FC = () => {
         It is unclear why the /create routes need to be listed after the /:id routes. It
         seems backwards from what the react-router docs suggest, but it's what works.
         */}
-        <AuthRoute exact path={paths.sample(":submissionId", ":sampleIndex")}>
+        <AuthRoute
+          exact
+          path={paths.sample(":submissionId", ":template", ":sampleIndex")}
+        >
           <SamplePage />
         </AuthRoute>
         <AuthRoute exact path={paths.studyEdit(":submissionId")}>

--- a/src/api.ts
+++ b/src/api.ts
@@ -82,7 +82,9 @@ export interface SampleData {
 }
 
 export interface IndexedSampleData extends SampleData {
-  _index: number;
+  _flatIndex: number;
+  _templateIndex: number;
+  _template: TemplateName;
 }
 
 // This should eventually come from the schema itself
@@ -154,7 +156,7 @@ export type TemplateName = keyof typeof TEMPLATES;
 export type SlotName = string;
 
 export interface MetadataSubmission {
-  packageName: TemplateName | "";
+  packageName: TemplateName | TemplateName[] | "";
   contextForm: ContextForm;
   addressForm: AddressForm;
   templates: string[];

--- a/src/components/SampleList/SampleList.module.css
+++ b/src/components/SampleList/SampleList.module.css
@@ -1,0 +1,15 @@
+.searchAndFilterContainer {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: 10px;
+}
+
+.filterContainer {
+  white-space: nowrap;
+  overflow-x: auto;
+}
+
+.searchButton {
+  margin-left: 10px;
+}

--- a/src/components/SampleList/SampleList.tsx
+++ b/src/components/SampleList/SampleList.tsx
@@ -16,7 +16,7 @@ import {
 import paths from "../../paths";
 import { search as searchIcon } from "ionicons/icons";
 import NoneOr from "../NoneOr/NoneOr";
-import { IndexedSampleData, SubmissionMetadata } from "../../api";
+import { IndexedSampleData, SubmissionMetadata, TemplateName } from "../../api";
 import { IonSearchbarCustomEvent } from "@ionic/core/dist/types/components";
 import { useMiniSearch } from "react-minisearch";
 import { getSubmissionTemplates, getSubmissionSamples } from "../../utils";
@@ -38,7 +38,7 @@ const steps: Array<StepType> = [
 interface SampleListProps {
   submission: SubmissionMetadata;
   collapsedSize?: number;
-  onSampleCreate: (template: string) => void;
+  onSampleCreate: (template: TemplateName) => void;
   sampleCreateFailureMessage?: string;
 }
 
@@ -89,12 +89,13 @@ const SampleList: React.FC<SampleListProps> = ({
     // the list of samples and in the search index.
     let flatIndex = 0;
     Object.entries(samplesMap).forEach(([template, samples]) => {
+      const templateName = template as TemplateName;
       samples.forEach((sample, index) => {
         flattenedSamples.push({
           ...sample,
           _flatIndex: flatIndex++,
           _templateIndex: index,
-          _template: template,
+          _template: templateName,
         });
       });
     });

--- a/src/components/SampleView/SampleView.tsx
+++ b/src/components/SampleView/SampleView.tsx
@@ -23,7 +23,7 @@ function formatSlotValue(value: SampleDataValue) {
 
 interface SampleViewProps {
   onSlotClick: (slot: SlotDefinition) => void;
-  packageName: TemplateName;
+  template: TemplateName;
   sample?: SampleData;
   schema: SchemaDefinition;
   validationResults?: Record<string, string>;
@@ -31,13 +31,13 @@ interface SampleViewProps {
 }
 const SampleView: React.FC<SampleViewProps> = ({
   onSlotClick,
-  packageName,
+  template,
   sample,
   schema,
   validationResults,
   visibleSlots,
 }) => {
-  const schemaClass = TEMPLATES[packageName].schemaClass;
+  const schemaClass = TEMPLATES[template].schemaClass;
   const slots: SlotDefinition[] = useMemo(() => {
     const allSlots = Object.values(
       schema.classes?.[schemaClass]?.attributes || {},

--- a/src/components/StudyForm/StudyForm.tsx
+++ b/src/components/StudyForm/StudyForm.tsx
@@ -11,7 +11,7 @@ import {
 } from "@ionic/react";
 import RequiredMark from "../RequiredMark/RequiredMark";
 import SectionHeader from "../SectionHeader/SectionHeader";
-import { SubmissionMetadataCreate, TEMPLATES } from "../../api";
+import { SubmissionMetadataCreate, TemplateName, TEMPLATES } from "../../api";
 import { Controller, useForm } from "react-hook-form";
 import { useStore } from "../../Store";
 import { StepType } from "@reactour/tour";
@@ -283,7 +283,10 @@ const StudyForm: React.FC<StudyFormProps> = ({
                       "metadata_submission.templates",
                       newPackageName.concat(
                         templates.filter(
-                          (template) => !previousPackageName.includes(template),
+                          (template) =>
+                            !previousPackageName.includes(
+                              template as TemplateName,
+                            ),
                         ),
                       ),
                     );

--- a/src/components/StudyForm/StudyForm.tsx
+++ b/src/components/StudyForm/StudyForm.tsx
@@ -79,7 +79,7 @@ const StudyForm: React.FC<StudyFormProps> = ({
 
   const { loggedInUser } = useStore();
 
-  const { handleSubmit, control, formState, setValue } =
+  const { handleSubmit, control, formState, setValue, getValues } =
     useForm<SubmissionMetadataCreate>({
       defaultValues: submission,
       mode: "onTouched",
@@ -257,11 +257,38 @@ const StudyForm: React.FC<StudyFormProps> = ({
                 data-tour={`${TourId.StudyForm}-2`}
                 className={`${(fieldState.isTouched || formState.isSubmitted) && "ion-touched"} ${fieldState.invalid && "ion-invalid"}`}
                 labelPlacement="floating"
+                multiple={Array.isArray(field.value)}
                 onIonDismiss={field.onBlur}
                 onIonChange={(e) => {
-                  // these two fields need to stay in sync
-                  setValue("metadata_submission.templates.0", e.detail.value);
-                  field.onChange(e.detail.value);
+                  // The `packageName` and `templates` fields need to stay in sync.
+                  const previousPackageName = getValues(
+                    "metadata_submission.packageName",
+                  );
+                  const newPackageName = e.detail.value;
+                  // The value of the `packageName` field is typed to be a string or an array of
+                  // strings to ease the transition between the formats that the backend accepts.
+                  // Once the transition is complete, this logic can be simplified to only use
+                  // the array format.
+                  if (typeof previousPackageName === "string") {
+                    // If the previous value was a string, just replace the first element of
+                    // the templates array with the new package name.
+                    setValue("metadata_submission.templates.0", newPackageName);
+                  } else if (Array.isArray(previousPackageName)) {
+                    // If the previous value was a string, remove all the previous package names
+                    // from the templates array and prepend the new package names.
+                    const templates = getValues(
+                      "metadata_submission.templates",
+                    );
+                    setValue(
+                      "metadata_submission.templates",
+                      newPackageName.concat(
+                        templates.filter(
+                          (template) => !previousPackageName.includes(template),
+                        ),
+                      ),
+                    );
+                  }
+                  field.onChange(newPackageName);
                 }}
                 {...field}
               >

--- a/src/components/StudyList/StudyList.tsx
+++ b/src/components/StudyList/StudyList.tsx
@@ -14,7 +14,7 @@ import {
 } from "@ionic/react";
 import { SubmissionMetadata } from "../../api";
 import Pluralize from "../Pluralize/Pluralize";
-import { getSubmissionSamples } from "../../utils";
+import { getSubmissionSamplesCount, getSubmissionTemplates } from "../../utils";
 import paths from "../../paths";
 import NoneOr from "../NoneOr/NoneOr";
 import QueryErrorBanner from "../QueryErrorBanner/QueryErrorBanner";
@@ -98,11 +98,11 @@ const StudyList: React.FC = () => {
                       </h3>
                       <p>
                         <NoneOr placeholder="No template selected">
-                          {submission.metadata_submission.templates[0]}
+                          {getSubmissionTemplates(submission).join(", ")}
                         </NoneOr>
                         {" • "}
                         <Pluralize
-                          count={getSubmissionSamples(submission).length}
+                          count={getSubmissionSamplesCount(submission)}
                           singular="Sample"
                           showCount
                         />

--- a/src/components/StudyView/StudyView.tsx
+++ b/src/components/StudyView/StudyView.tsx
@@ -71,7 +71,7 @@ const StudyView: React.FC<StudyViewProps> = ({ submissionId }) => {
 
   useEffect(() => {
     // If the slot selector is not already open, iterate through the study's templates. If one of
-    // them has no visible slot information (this could be because it is a brand-new study or
+    // them has no slot visibility information (this could be because it is a brand-new study or
     // because it was created via the submission portal and this is the first time opening it in the
     // app), open the slot selector for that template.
     if (

--- a/src/components/StudyView/StudyView.tsx
+++ b/src/components/StudyView/StudyView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import { useSubmission } from "../../queries";
 import {
   IonItem,
@@ -8,7 +8,6 @@ import {
   IonRefresherContent,
   RefresherEventDetail,
   useIonRouter,
-  useIonViewDidEnter,
 } from "@ionic/react";
 import SectionHeader from "../SectionHeader/SectionHeader";
 import NoneOr from "../NoneOr/NoneOr";
@@ -35,13 +34,9 @@ interface TemplateVisibleSlots {
 
 interface StudyViewProps {
   submissionId: string;
-  openSlotSelectorModalOnEnter?: boolean;
 }
 
-const StudyView: React.FC<StudyViewProps> = ({
-  submissionId,
-  openSlotSelectorModalOnEnter = false,
-}) => {
+const StudyView: React.FC<StudyViewProps> = ({ submissionId }) => {
   const router = useIonRouter();
   const {
     query: submission,
@@ -71,11 +66,21 @@ const StudyView: React.FC<StudyViewProps> = ({
     return fieldVisibilityInfo;
   }, [submission.data]);
 
-  useIonViewDidEnter(() => {
-    if (openSlotSelectorModalOnEnter) {
-      setModalTemplateVisibleSlots(templateVisibleSlots[0]);
+  useEffect(() => {
+    // If the slot selector is not already open, iterate through the study's templates. If one of
+    // them has no visible slot information (this could be because it is a brand-new study or
+    // because it was created via the submission portal and this is the first time opening it in the
+    // app), open the slot selector for that template.
+    if (modalTemplateVisibleSlots !== undefined) {
+      return;
     }
-  }, [openSlotSelectorModalOnEnter, templateVisibleSlots]);
+    for (const item of templateVisibleSlots) {
+      if (item.visibleSlots === undefined) {
+        setModalTemplateVisibleSlots(item);
+        return;
+      }
+    }
+  }, [modalTemplateVisibleSlots, templateVisibleSlots]);
 
   const handleSampleCreate = async (template: TemplateName) => {
     if (!submission.data) {

--- a/src/components/StudyView/StudyView.tsx
+++ b/src/components/StudyView/StudyView.tsx
@@ -50,6 +50,9 @@ const StudyView: React.FC<StudyViewProps> = ({ submissionId }) => {
   const templateVisibleSlots = useMemo(() => {
     const fieldVisibilityInfo: TemplateVisibleSlots[] = [];
     if (submission.data) {
+      if (!("field_notes_metadata" in submission.data)) {
+        return undefined;
+      }
       const templates = getSubmissionTemplates(submission.data);
       templates.forEach((templateName) => {
         const template = TEMPLATES[templateName];
@@ -71,7 +74,10 @@ const StudyView: React.FC<StudyViewProps> = ({ submissionId }) => {
     // them has no visible slot information (this could be because it is a brand-new study or
     // because it was created via the submission portal and this is the first time opening it in the
     // app), open the slot selector for that template.
-    if (modalTemplateVisibleSlots !== undefined) {
+    if (
+      modalTemplateVisibleSlots !== undefined ||
+      templateVisibleSlots === undefined
+    ) {
       return;
     }
     for (const item of templateVisibleSlots) {
@@ -227,33 +233,37 @@ const StudyView: React.FC<StudyViewProps> = ({ submissionId }) => {
             </IonItem>
           </IonList>
 
-          <SectionHeader>Templates</SectionHeader>
-          <IonList className="ion-padding-bottom">
-            {templateVisibleSlots.map((item) => (
-              <IonItem
-                key={item.template}
-                onClick={() => setModalTemplateVisibleSlots(item)}
-              >
-                <IonLabel>
-                  <h3>{item.templateDisplay}</h3>
-                  <p>
-                    {item.visibleSlots === undefined ? (
-                      "Not customized"
-                    ) : (
-                      <>
-                        <Pluralize
-                          count={item.visibleSlots.length}
-                          singular={"field"}
-                          showCount
-                        />{" "}
-                        selected
-                      </>
-                    )}
-                  </p>
-                </IonLabel>
-              </IonItem>
-            ))}
-          </IonList>
+          {templateVisibleSlots !== undefined && (
+            <>
+              <SectionHeader>Templates</SectionHeader>
+              <IonList className="ion-padding-bottom">
+                {templateVisibleSlots.map((item) => (
+                  <IonItem
+                    key={item.template}
+                    onClick={() => setModalTemplateVisibleSlots(item)}
+                  >
+                    <IonLabel>
+                      <h3>{item.templateDisplay}</h3>
+                      <p>
+                        {item.visibleSlots === undefined ? (
+                          "Not customized"
+                        ) : (
+                          <>
+                            <Pluralize
+                              count={item.visibleSlots.length}
+                              singular={"field"}
+                              showCount
+                            />{" "}
+                            selected
+                          </>
+                        )}
+                      </p>
+                    </IonLabel>
+                  </IonItem>
+                ))}
+              </IonList>
+            </>
+          )}
 
           <SampleList
             submission={submission.data}

--- a/src/components/StudyView/StudyView.tsx
+++ b/src/components/StudyView/StudyView.tsx
@@ -13,7 +13,10 @@ import {
 import SectionHeader from "../SectionHeader/SectionHeader";
 import NoneOr from "../NoneOr/NoneOr";
 import SampleList from "../SampleList/SampleList";
-import { getSubmissionSamples } from "../../utils";
+import {
+  getSubmissionSamples,
+  getSubmissionSamplesForTemplate,
+} from "../../utils";
 import { produce } from "immer";
 import paths from "../../paths";
 import { useNetworkStatus } from "../../NetworkStatus";
@@ -73,7 +76,7 @@ const StudyView: React.FC<StudyViewProps> = ({
     }
   }, [openSlotSelectorModalOnEnter, templateVisibleSlots]);
 
-  const handleSampleCreate = async () => {
+  const handleSampleCreate = async (template: string) => {
     if (!submission.data) {
       return;
     }
@@ -90,13 +93,13 @@ const StudyView: React.FC<StudyViewProps> = ({
       const samples = getSubmissionSamples(draft, {
         createSampleDataFieldIfMissing: true,
       });
-      samples.push({});
+      samples[template].push({});
     });
     updateMutation.mutate(updatedSubmission, {
       onSuccess: (result) => {
-        const samples = getSubmissionSamples(result);
+        const samples = getSubmissionSamplesForTemplate(result, template);
         router.push(
-          paths.sample(submissionId, samples.length - 1),
+          paths.sample(submissionId, template, samples.length - 1),
           "forward",
           "push",
         );

--- a/src/data.ts
+++ b/src/data.ts
@@ -68,7 +68,7 @@ export const initMetadataSubmission = (): MetadataSubmission => ({
   addressForm: initAddressForm(),
   contextForm: initContextForm(),
   multiOmicsForm: initMultiOmicsForm(),
-  packageName: "",
+  packageName: "", // TODO: CHANGE DEFAULT WHEN BACKEND IS UPDATED
   sampleData: {},
   studyForm: initStudyForm(),
   templates: [],

--- a/src/data.ts
+++ b/src/data.ts
@@ -68,7 +68,7 @@ export const initMetadataSubmission = (): MetadataSubmission => ({
   addressForm: initAddressForm(),
   contextForm: initContextForm(),
   multiOmicsForm: initMultiOmicsForm(),
-  packageName: "", // TODO: CHANGE DEFAULT WHEN BACKEND IS UPDATED
+  packageName: "", // TODO: CHANGE DEFAULT VALUE TO EMPTY ARRAY WHEN BACKEND IS UPDATED
   sampleData: {},
   studyForm: initStudyForm(),
   templates: [],

--- a/src/pages/SamplePage/SamplePage.tsx
+++ b/src/pages/SamplePage/SamplePage.tsx
@@ -24,7 +24,12 @@ import {
   getSubmissionSample,
   getSubmissionSamplesForTemplate,
 } from "../../utils";
-import {SampleData, SampleDataValue, TemplateName, TEMPLATES} from "../../api";
+import {
+  SampleData,
+  SampleDataValue,
+  TemplateName,
+  TEMPLATES,
+} from "../../api";
 import SampleView from "../../components/SampleView/SampleView";
 import { SlotDefinition, SlotDefinitionName } from "../../linkml-metamodel";
 import SampleSlotEditModal from "../../components/SampleSlotEditModal/SampleSlotEditModal";

--- a/src/pages/StudyCreatePage/StudyCreatePage.tsx
+++ b/src/pages/StudyCreatePage/StudyCreatePage.tsx
@@ -17,11 +17,10 @@ import { checkmark } from "ionicons/icons";
 import ThemedToolbar from "../../components/ThemedToolbar/ThemedToolbar";
 import { useNetworkStatus } from "../../NetworkStatus";
 import FixedCenteredMessage from "../../components/FixedCenteredMessage/FixedCenteredMessage";
-import { StudyViewPageLocationState } from "../StudyViewPage/StudyViewPage";
 import useNavigateWithState from "../../useNavigateWithState";
 
 const StudyCreatePage: React.FC = () => {
-  const navigate = useNavigateWithState<StudyViewPageLocationState>();
+  const navigate = useNavigateWithState();
   const [present] = useIonToast();
   const submissionCreate = useSubmissionCreate();
   const submission = useMemo(initSubmission, []);
@@ -35,13 +34,7 @@ const StudyCreatePage: React.FC = () => {
           duration: 3000,
           icon: checkmark,
         });
-        navigate(
-          paths.studyView(created.id),
-          {
-            openSlotSelectorModalOnEnter: true,
-          },
-          true,
-        );
+        navigate(paths.studyView(created.id), undefined, true);
       },
     });
   };

--- a/src/pages/StudyViewPage/StudyViewPage.tsx
+++ b/src/pages/StudyViewPage/StudyViewPage.tsx
@@ -12,19 +12,13 @@ import {
 import StudyView from "../../components/StudyView/StudyView";
 import paths from "../../paths";
 import ThemedToolbar from "../../components/ThemedToolbar/ThemedToolbar";
-import useNavigationState from "../../useNavigationState";
 
 interface StudyViewPageParams {
   submissionId: string;
 }
 
-export interface StudyViewPageLocationState {
-  openSlotSelectorModalOnEnter?: boolean;
-}
-
 const StudyViewPage: React.FC = () => {
   const { submissionId } = useParams<StudyViewPageParams>();
-  const state = useNavigationState<StudyViewPageLocationState>();
 
   return (
     <IonPage>
@@ -42,10 +36,7 @@ const StudyViewPage: React.FC = () => {
         </ThemedToolbar>
       </IonHeader>
       <IonContent>
-        <StudyView
-          submissionId={submissionId}
-          openSlotSelectorModalOnEnter={state?.openSlotSelectorModalOnEnter}
-        />
+        <StudyView submissionId={submissionId} />
       </IonContent>
     </IonPage>
   );

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -14,8 +14,11 @@ const paths = {
   studyCreate: `${STUDY}/create`,
   studyView: (submissionId: string) => `${STUDY}/${submissionId}`,
   studyEdit: (submissionId: string) => `${STUDY}/${submissionId}/edit`,
-  sample: (submissionId: string, sampleIndex: string | number) =>
-    `${STUDY}/${submissionId}/sample/${sampleIndex}`,
+  sample: (
+    submissionId: string,
+    template: string,
+    sampleIndex: string | number,
+  ) => `${STUDY}/${submissionId}/sample/${template}/${sampleIndex}`,
   guide: `${IN}/guide`,
   settings: `${IN}${SETTINGS}`,
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,41 +1,132 @@
 import React from "react";
-import { SubmissionMetadata, TEMPLATES } from "./api";
-import { SlotDefinition } from "./linkml-metamodel";
+import { SampleData, SubmissionMetadata, TemplateName, TEMPLATES } from "./api";
+import { SchemaDefinition, SlotDefinition } from "./linkml-metamodel";
+
+/**
+ * Get the templates associated with a submission.
+ *
+ * This function is mainly useful to ease the transition between the old format where the
+ * `packageName` field was a string and the new format where it is an array of strings.
+ * This function always returns an array of strings.
+ *
+ * @param submission
+ */
+export function getSubmissionTemplates(
+  submission?: SubmissionMetadata,
+): TemplateName[] {
+  if (!submission) {
+    return [];
+  }
+  const { packageName } = submission.metadata_submission;
+  if (typeof packageName === "string") {
+    return [packageName];
+  }
+  return packageName;
+}
 
 export interface GetSubmissionSamplesOptions {
   createSampleDataFieldIfMissing?: boolean;
 }
+
+/**
+ * Get the samples associated with a submission.
+ *
+ * Returns an object where the keys are the templates and the values are arrays of sample data
+ * objects for that template. If the `createSampleDataFieldIfMissing` option is set to true, it
+ * will modify the submission object to add missing template fields, defaulting to an empty array.
+ *
+ * @param submission
+ * @param options
+ */
 export function getSubmissionSamples(
   submission?: SubmissionMetadata,
   options: GetSubmissionSamplesOptions = {},
-) {
+): Record<TemplateName, SampleData[]> {
   if (!submission) {
-    return [];
+    return {};
   }
-  const environmentalPackageName = submission.metadata_submission.packageName;
-  const sampleDataField = environmentalPackageName
-    ? TEMPLATES[environmentalPackageName].sampleDataSlot
-    : undefined;
-  if (!sampleDataField) {
-    return [];
-  }
-  if (
-    !(sampleDataField in submission.metadata_submission.sampleData) &&
-    options.createSampleDataFieldIfMissing
-  ) {
-    submission.metadata_submission.sampleData[sampleDataField] = [];
-  }
-  return submission.metadata_submission.sampleData[sampleDataField] || [];
+  const samples: Record<TemplateName, SampleData[]> = {};
+  const templates = getSubmissionTemplates(submission);
+  templates.forEach((template) => {
+    const sampleDataSlot = TEMPLATES[template]?.sampleDataSlot;
+    if (!sampleDataSlot) {
+      return;
+    }
+    if (
+      !(sampleDataSlot in submission.metadata_submission.sampleData) &&
+      options.createSampleDataFieldIfMissing
+    ) {
+      submission.metadata_submission.sampleData[sampleDataSlot] = [];
+    }
+    samples[template] =
+      submission.metadata_submission.sampleData[sampleDataSlot] || [];
+  });
+  return samples;
 }
 
+/**
+ * Get the total number of samples associated with a submission across all templates.
+ *
+ * @param submission
+ */
+export function getSubmissionSamplesCount(
+  submission?: SubmissionMetadata,
+): number {
+  if (submission === undefined) {
+    return 0;
+  }
+  let count = 0;
+  const templates = getSubmissionTemplates(submission);
+  templates.forEach((template) => {
+    const sampleDataSlot = TEMPLATES[template]?.sampleDataSlot;
+    if (!sampleDataSlot) {
+      return;
+    }
+    const samples =
+      submission.metadata_submission.sampleData[sampleDataSlot] || [];
+    count += samples.length;
+  });
+  return count;
+}
+
+/**
+ * Get the samples associated with a specific template in a submission.
+ *
+ * @param submission
+ * @param template
+ */
+export function getSubmissionSamplesForTemplate(
+  submission?: SubmissionMetadata,
+  template?: TemplateName,
+): SampleData[] {
+  if (!submission || template === undefined) {
+    return [];
+  }
+  const samplesByTemplate = getSubmissionSamples(submission);
+  if (samplesByTemplate[template] === undefined) {
+    return [];
+  }
+  return samplesByTemplate[template];
+}
+
+/**
+ * Get a specific sample associated with a submission.
+ *
+ * The sample is identified by the template and the index within that template's sample array.
+ *
+ * @param submission
+ * @param template
+ * @param index
+ */
 export function getSubmissionSample(
   submission?: SubmissionMetadata,
+  template?: TemplateName,
   index?: number,
 ) {
-  if (!submission || index === undefined) {
+  if (!submission || template === undefined || index === undefined) {
     return undefined;
   }
-  return getSubmissionSamples(submission)[index];
+  return getSubmissionSamples(submission)[template][index];
 }
 
 export interface SlotGroup {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import React from "react";
 import { SampleData, SubmissionMetadata, TemplateName, TEMPLATES } from "./api";
-import { SchemaDefinition, SlotDefinition } from "./linkml-metamodel";
+import { SlotDefinition } from "./linkml-metamodel";
 
 /**
  * Get the templates associated with a submission.
@@ -19,7 +19,11 @@ export function getSubmissionTemplates(
   }
   const { packageName } = submission.metadata_submission;
   if (typeof packageName === "string") {
-    return [packageName];
+    if (packageName === "") {
+      return [];
+    } else {
+      return [packageName];
+    }
   }
   return packageName;
 }
@@ -41,11 +45,11 @@ export interface GetSubmissionSamplesOptions {
 export function getSubmissionSamples(
   submission?: SubmissionMetadata,
   options: GetSubmissionSamplesOptions = {},
-): Record<TemplateName, SampleData[]> {
+): Partial<Record<TemplateName, SampleData[]>> {
   if (!submission) {
     return {};
   }
-  const samples: Record<TemplateName, SampleData[]> = {};
+  const samples: Partial<Record<TemplateName, SampleData[]>> = {};
   const templates = getSubmissionTemplates(submission);
   templates.forEach((template) => {
     const sampleDataSlot = TEMPLATES[template]?.sampleDataSlot;
@@ -103,10 +107,11 @@ export function getSubmissionSamplesForTemplate(
     return [];
   }
   const samplesByTemplate = getSubmissionSamples(submission);
-  if (samplesByTemplate[template] === undefined) {
+  const templateSamples = samplesByTemplate[template];
+  if (templateSamples === undefined) {
     return [];
   }
-  return samplesByTemplate[template];
+  return templateSamples;
 }
 
 /**
@@ -126,7 +131,11 @@ export function getSubmissionSample(
   if (!submission || template === undefined || index === undefined) {
     return undefined;
   }
-  return getSubmissionSamples(submission)[template][index];
+  const samplesForTemplate = getSubmissionSamples(submission)[template];
+  if (samplesForTemplate === undefined) {
+    return undefined;
+  }
+  return samplesForTemplate[index];
 }
 
 export interface SlotGroup {


### PR DESCRIPTION
Fixes #177 

### Summary

These changes add support for selecting multiple environmental templates. This is enabled by backend support provided by https://github.com/microbiomedata/nmdc-server/pull/1372 and https://github.com/microbiomedata/nmdc-server/pull/1491.

Because we can't 100% control the timing of the app's release relative to the backend's release, the overall approach of these changes is to make the app agnostic to the `packageName` field being a single string (the old single template format) _or_ an array of strings (the new multiple template format).

The one thing that the app can't know _a priori_ is whether it should send a single string or an array of strings when creating a new submission (if you're working with an existing submission the app will just keep whatever it was given -- string or array -- by the backend). The one place that's controlled is in `src/data.ts` and that's what we'll need to change once the backend changes are on production and we're ready to have multiple environment selection be the default.

### Details

* Most of the logic to normalize `packageName` as a string vs an array of strings is encapsulated in new function in `src/utils.ts`. 
  * `getSubmissionTemplates` is new and returns an array of template names regardless of whether the submission's `packageName` field is a string or an array of strings.
  * `getSubmissionSamples` previously returned a list of sample metadata objects. Now it returns an object where each key is a template name and the value is a list of sample metadata objects for that template.
  * `getSubmissionSamplesCount` adds up the number of sample metadata objects across all of the templates.
  * `getSubmissionSamplesForTemplate` is new and is mainly a shortcut for indexing into the object returned by `getSubmissionSamples`. 
  * `getSubmissionSample` previously only needed an numeric index to identify a single sample within a submission. Now it needs both a template name _and_ a numeric index.
* Because samples are now identified by their template plus a numeric index, the `SamplePage` now requires a `template` parameter. This is also reflected in the routing to this page (see: `src/Router.tsx`, `src/paths.ts`, `src/components/SampleList/SampleList.tsx`)
* The `SampleList` component still displays all samples in a single flat list. This means it needs to do a little extra work to keep track of a "flattened index" for the purpose of uniquely identifying samples _in that list_. It also needs to ask the user which template to use when creating a new sample (if more than one template is associated with the study). And finally the `IonChip` elements it presents are now interactive, as a way to filter the samples by template.
* When editing a study (`src/components/StudyForm/StudyForm.tsx`) there was existing logic to keep two _backend_ data fields (`packageName` and `templates`) in sync (arguably the backend should do this automatically, but it doesn't for reasons perhaps lost to history). This logic got a bit more complex in order to handle both plain strings and arrays of strings.
* `StudyView` (`src/components/StudyView/StudyView.tsx`) has been updated so that it automatically shows the slot selector modal for _each_ template where the user has yet to choose visible slots for that template. This actually removes a bit of the logic based on routing state introduced in #206. After thinking about it more, I realized we should probably just prompt the user to choose their visible slots if they haven't done so already no matter how they landed on that page. Mainly I'm thinking about the use case where someone creates a submission in the Submission Portal and then starts working with that submission in the app. We wouldn't want them to miss the slot visibility selection step just because they didn't create the submission in the app.
* There are a number of places where I'm just standardizing the app's terminology and variable naming around the term "template". Previously, there were some places where the same concept was called "package name" in the code. That is what the backend calls it (again, reasons lost to time), but I wanted the app's code to at least be consistent with itself.

### Testing

The most important thing is that these change should work while talking to a backend running the latest `nmdc-server` changes (i.e. running the `main` branch locally or pointing to `data-dev.microbiomedata.org`) _or_ the current production `nmdc-server` version (i.e. running the `v1.1.1` tag locall or pointing to `data.microbiomedata.org`).

Using either backend you should be able to create new submissions, edit existing ones, and add samples to a submission.

You will see slightly different behaviors when using the dev vs. prod backends. When using dev you should see the templates explicitly listed on the study view page, and tapping on one should bring up the slot selection modal. You will not see on that prod because that version of the backend does not support it yet. 