### PR TITLE
Enable multiple templates by default

### DIFF
--- a/src/components/StudyForm/StudyForm.tsx
+++ b/src/components/StudyForm/StudyForm.tsx
@@ -34,8 +34,8 @@ const steps: Array<StepType> = [
     selector: `[data-tour="${TourId.StudyForm}-2"]`,
     content: (
       <>
-        Here, you can select a template that reflects the kind of environment
-        you&apos;ll be collecting samples from.
+        Here, you can select the templates that reflects the kind of
+        environments you&apos;ll be collecting samples from.
       </>
     ),
   },
@@ -296,7 +296,7 @@ const StudyForm: React.FC<StudyFormProps> = ({
                 {...field}
               >
                 <div slot="label">
-                  Template
+                  Templates
                   <RequiredMark />
                 </div>
                 {Object.entries(TEMPLATES).map(([key, template]) => (

--- a/src/components/StudyForm/StudyForm.tsx
+++ b/src/components/StudyForm/StudyForm.tsx
@@ -34,7 +34,7 @@ const steps: Array<StepType> = [
     selector: `[data-tour="${TourId.StudyForm}-2"]`,
     content: (
       <>
-        Here, you can select the templates that reflects the kind of
+        Here, you can select the templates that reflect the kinds of
         environments you&apos;ll be collecting samples from.
       </>
     ),

--- a/src/data.ts
+++ b/src/data.ts
@@ -68,7 +68,7 @@ export const initMetadataSubmission = (): MetadataSubmission => ({
   addressForm: initAddressForm(),
   contextForm: initContextForm(),
   multiOmicsForm: initMultiOmicsForm(),
-  packageName: "", // TODO: CHANGE DEFAULT VALUE TO EMPTY ARRAY WHEN BACKEND IS UPDATED
+  packageName: [],
   sampleData: {},
   studyForm: initStudyForm(),
   templates: [],

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -91,11 +91,13 @@
 :root {
   --ion-background-color: #ffffff;
   --ion-background-color-rgb: rgb(255, 255, 255);
+  --ion-item-background: var(--ion-background-color);
 }
 
 :root.ion-palette-dark {
   --ion-background-color: #000000;
   --ion-background-color-rgb: rgb(0, 0, 0);
+  --ion-item-background: var(--ion-background-color);
 }
 
 /**


### PR DESCRIPTION
Now that Release 2024.12 is on production, these changes complete the corresponding app changes by enabling multiple environment selection for new studies.

I also made a small unrelated tweak to the theme stylesheet so that list items don't have an award gray background on Android in dark mode. These changes ensure that list items always have the same background color as the main interface no matter what platform or light/dark mode.