### PR TITLE
Simplify "Welcome" screen (remove obsolete items and spread others out)

### DIFF
--- a/src/pages/WelcomePage/WelcomePage.tsx
+++ b/src/pages/WelcomePage/WelcomePage.tsx
@@ -39,47 +39,35 @@ const WelcomePage: React.FC = () => {
         className={`ion-padding ${classes.themedBackground}`}
       >
         <IonGrid className={classes.fullHeight}>
-          <IonRow className={`${classes.fullHeight} ion-align-items-center`}>
-            <IonCol>
+          <IonRow
+            className={`${classes.fullHeight} ion-align-items-stretch ion-justify-content-between`}
+          >
+            <IonCol size={"12"} className={"ion-text-center"}>
+              <Logo className={classes.marginAuto} />
+            </IonCol>
+            <IonCol
+              size={"12"}
+              className={"ion-text-center ion-align-self-center"}
+            >
+              <IonCard>
+                <IonCardHeader>
+                  <IonCardTitle>Welcome</IonCardTitle>
+                </IonCardHeader>
+                <IonCardContent className={classes.paddingBottomZero}>
+                  Welcome to NMDC Field Notes, an app designed to help you
+                  collect environmental metadata on&nbsp;the&nbsp;go.
+                </IonCardContent>
+                <IonButton
+                  fill={"clear"}
+                  href={"https://microbiomedata.org/field-notes/"}
+                >
+                  Learn more
+                </IonButton>
+              </IonCard>
+            </IonCol>
+            <IonCol size={"12"} className={"ion-align-self-end"}>
               <IonRow>
-                <IonCol className={"ion-text-center"}>
-                  <Logo className={classes.marginAuto} />
-                </IonCol>
-              </IonRow>
-              <IonRow>
-                <IonCol className={"ion-text-center"}>
-                  <IonCard className={classes.marginBottomZero}>
-                    <IonCardHeader>
-                      <IonCardTitle>Welcome</IonCardTitle>
-                    </IonCardHeader>
-                    <IonCardContent className={classes.paddingBottomZero}>
-                      Welcome to NMDC Field Notes, an app designed to help you
-                      collect environmental metadata on the go.
-                    </IonCardContent>
-                    <IonButton fill={"clear"} routerLink={paths.tour}>
-                      Take a tour
-                    </IonButton>
-                  </IonCard>
-                </IonCol>
-              </IonRow>
-              <IonRow>
-                <IonCol className={"ion-text-center"}>
-                  <IonCard>
-                    <IonCardHeader>
-                      <IonCardTitle>Checklist</IonCardTitle>
-                    </IonCardHeader>
-                    <IonCardContent className={classes.paddingBottomZero}>
-                      Before you go out into the field, do you have everything
-                      you need to collect your metadata?
-                    </IonCardContent>
-                    <IonButton fill={"clear"} routerLink={paths.checklist}>
-                      View the checklist
-                    </IonButton>
-                  </IonCard>
-                </IonCol>
-              </IonRow>
-              <IonRow>
-                <IonCol className={"ion-text-center"}>
+                <IonCol size={"12"} className={"ion-text-center"}>
                   <IonButton
                     expand={"block"}
                     className={"ion-margin-horizontal"}
@@ -93,9 +81,7 @@ const WelcomePage: React.FC = () => {
                     Log in with ORCiD
                   </IonButton>
                 </IonCol>
-              </IonRow>
-              <IonRow>
-                <IonCol className={"ion-text-center"}>
+                <IonCol size={"12"} className={"ion-text-center"}>
                   <IonButton
                     fill={"clear"}
                     id={"show-alert-for-continue-without-login"}
@@ -106,29 +92,29 @@ const WelcomePage: React.FC = () => {
                   </IonButton>
                 </IonCol>
               </IonRow>
-              <IonAlert
-                trigger={"show-alert-for-continue-without-login"}
-                header={"Continue without logging in?"}
-                message={
-                  "You will need to log in before you can sync metadata with the NMDC Submission Portal."
-                }
-                buttons={[
-                  {
-                    text: "Cancel",
-                    role: "cancel",
-                  },
-                  {
-                    text: "Continue",
-                    role: "confirm",
-                    handler: () => {
-                      router.push(paths.home, "forward");
-                    },
-                  },
-                ]}
-              ></IonAlert>
             </IonCol>
           </IonRow>
         </IonGrid>
+        <IonAlert
+          trigger={"show-alert-for-continue-without-login"}
+          header={"Continue without logging in?"}
+          message={
+            "You will need to log in before you can sync metadata with the NMDC Submission Portal."
+          }
+          buttons={[
+            {
+              text: "Cancel",
+              role: "cancel",
+            },
+            {
+              text: "Continue",
+              role: "confirm",
+              handler: () => {
+                router.push(paths.home, "forward");
+              },
+            },
+          ]}
+        ></IonAlert>
       </IonContent>
     </IonPage>
   );


### PR DESCRIPTION
Fixes #183 

### Summary

On this branch, I simplified the "Welcome" screen of the app.

### Details

On this branch, I made the following changes to the "Welcome" screen of the app, in an attempt to make it consistent with the functionality the app has today.

1. **The "Take a tour" link**: I replaced the "Take a tour" link with a "Learn more" link that points somewhere else.
   - The "Learn more" link points to a page about the NMDC Field Notes app, on the WordPress website (i.e., this page: https://microbiomedata.org/field-notes/).
2. **The "Checklist" card**: I removed the "Checklist" card entirely.
   - As @pkalita-lbl pointed out in [this comment](https://github.com/microbiomedata/nmdc-field-notes/issues/183#issuecomment-2455437070), the same checklist is already accessible from other screens of the app (e.g., the "Guide" tab in the center of our footer navigation bar leads to it).
3. **Spreading elements out vertically**: I spread out the remaining screen elements vertically.
   - Previously, the screen elements were vertically clumped at the middle of the screen; although — due to screen elements "pushing" subsequent elements downwards — this clustering was not distinguishable from the newly-implemented spreading, except on particularly tall screens (e.g., iPad), where the empty space above and below the clump would be more prominent.
   - I grouped the two action buttons together (e.g. "Log in..." and "Continue..."), so they would be spread from the other elements as a single unit.

Here is a pair of before-and-after screenshots showing how the appearance of the "Welcome" screen differs between `main` and this branch:

| Before (`main`) | After (this branch) |
| -- | -- |
| <img src="https://github.com/user-attachments/assets/9c047e1a-fc8a-4291-b82c-8928d74309f6" width="400" /> | <img src="https://github.com/user-attachments/assets/ba9ac158-afa4-4587-a4d8-32cd51da8a6e" width="400" /> |