### PR TITLE
Update tour navigation dots and button to use theme's primary color

### DIFF
--- a/src/components/AppTourProvider/AppTourProvider.tsx
+++ b/src/components/AppTourProvider/AppTourProvider.tsx
@@ -34,7 +34,11 @@ const AppTourProvider: React.FC<ProviderProps> = ({
         popover: (base) => ({
           ...base,
           borderRadius: 4,
+          // Make the tour text be legible over its background.
           color: "var(--ion-color-primary-contrast)",
+          // Make the navigation dots have the same color as the "Dismiss" button's background.
+          // Reference: https://docs.react.tours/tour/examples#custom-styles
+          "--reactour-accent": "var(--ion-color-primary)",
         }),
         // Style the hole in the mask (seems to impact light mode only 🤷).
         maskArea: (base) => ({ ...base, rx: 4 }),
@@ -74,7 +78,6 @@ const AppTourProvider: React.FC<ProviderProps> = ({
           <IonButton
             size={"small"}
             fill={"solid"}
-            color={"light"}
             onClick={() => props.setIsOpen(false)}
           >
             Dismiss


### PR DESCRIPTION
On this branch, I made two changes:
1. Update the color of the navigation dots in the tour popup, so they use the app theme's primary color (instead of the NPM package's default color, which was a different shade of blue)
2. Update the "Dismiss" button on the final step of the tour, so it matches the other buttons in the app (specifically, so its background color is the app theme's primary color)

Here are before-and-after screenshots:

### Before

- Left: iOS
- Right: Android

### Light palette

![image](https://github.com/user-attachments/assets/9c134c6d-1835-4edc-a761-3369e404f93a)

> I think I didn't notice the dot's blue shade before because the app theme's primary color was not present in the popup (out of sight, out of mind).

#### Dark palette

![image](https://github.com/user-attachments/assets/08c64213-702b-43f0-b742-eb4712870a15)

> I think I didn't notice the dot's blue shade before because the app theme's primary color was not present in the popup (out of sight, out of mind).

### After

- Left: iOS
- Right: Android

#### Light palette

![image](https://github.com/user-attachments/assets/054965d8-5a68-49c6-ae5f-26251620d3b7)

#### Dark palette

![image](https://github.com/user-attachments/assets/da36251c-9e75-4cec-9f70-044dc99c6fd8)