### PR TITLE
Let tours be skipped on view enter and started later imperatively

### DIFF
--- a/src/components/AppTourProvider/hooks.ts
+++ b/src/components/AppTourProvider/hooks.ts
@@ -2,33 +2,47 @@ import { StepType, useTour } from "@reactour/tour";
 import { TourId } from "./AppTourProvider";
 import { useStore } from "../../Store";
 import { useIonViewDidEnter } from "@ionic/react";
+import { useCallback } from "react";
 
 /**
  * Custom React hook that initializes a Reactour tour having the specified steps.
  */
-export const useAppTour = (tourId: TourId, steps: Array<StepType>) => {
+export const useAppTour = (
+  tourId: TourId,
+  steps: Array<StepType>,
+  showOnEnter: boolean = true,
+) => {
   const { setIsOpen, setSteps, setCurrentStep } = useTour();
   const { checkWhetherTourHasBeenPresented, rememberTourHasBeenPresented } =
     useStore();
+
+  const startTour = useCallback(() => {
+    if (setSteps === undefined || checkWhetherTourHasBeenPresented(tourId)) {
+      return;
+    }
+    setSteps(steps);
+    setCurrentStep(0);
+    setIsOpen(true);
+    rememberTourHasBeenPresented(tourId);
+  }, [
+    checkWhetherTourHasBeenPresented,
+    rememberTourHasBeenPresented,
+    setCurrentStep,
+    setIsOpen,
+    setSteps,
+    steps,
+    tourId,
+  ]);
 
   // Show the tour "when component routing has finished animating."
   // Reference: https://ionicframework.com/docs/react/lifecycle
   useIonViewDidEnter(() => {
     // Note: I don't know the circumstances under which `setSteps` would be `undefined`,
     //       but the TypeScript type information about `useTour` says it can be.
-    if (setSteps !== undefined && !checkWhetherTourHasBeenPresented(tourId)) {
-      setSteps(steps);
-      setCurrentStep(0);
-      setIsOpen(true);
-      rememberTourHasBeenPresented(tourId);
+    if (showOnEnter) {
+      startTour();
     }
-  }, [
-    steps,
-    setIsOpen,
-    setSteps,
-    setCurrentStep,
-    checkWhetherTourHasBeenPresented,
-    rememberTourHasBeenPresented,
-    tourId,
-  ]);
+  }, [checkWhetherTourHasBeenPresented, startTour, tourId]);
+
+  return { startTour };
 };

--- a/src/components/SampleList/SampleList.test.tsx
+++ b/src/components/SampleList/SampleList.test.tsx
@@ -32,7 +32,11 @@ const TestSampleList: React.FC<Props> = ({
   return (
     <>
       <button onClick={handleUpdateSubmission}>Update Submission</button>
-      <SampleList submission={submission} onSampleCreate={onSampleCreate} />
+      <SampleList
+        submission={submission}
+        onSampleCreate={onSampleCreate}
+        tourAllowed={false}
+      />
     </>
   );
 };

--- a/src/components/SampleList/SampleList.tsx
+++ b/src/components/SampleList/SampleList.tsx
@@ -41,6 +41,7 @@ interface SampleListProps {
   collapsedSize?: number;
   onSampleCreate: (template: TemplateName) => void;
   sampleCreateFailureMessage?: string;
+  tourAllowed?: boolean;
 }
 
 const SampleList: React.FC<SampleListProps> = ({
@@ -48,8 +49,9 @@ const SampleList: React.FC<SampleListProps> = ({
   collapsedSize = 5,
   onSampleCreate,
   sampleCreateFailureMessage,
+  tourAllowed = true,
 }) => {
-  useAppTour(TourId.SampleList, steps);
+  const { startTour } = useAppTour(TourId.SampleList, steps, false);
 
   const searchElement = React.useRef<HTMLIonSearchbarElement>(null);
 
@@ -119,6 +121,13 @@ const SampleList: React.FC<SampleListProps> = ({
       searchElement.current?.setFocus();
     }
   }, [isSearchVisible]);
+
+  // Attempt to start the tour when the tourAllowed prop changes.
+  useEffect(() => {
+    if (tourAllowed) {
+      startTour();
+    }
+  }, [tourAllowed, startTour]);
 
   const handleSearchInput = (
     event: IonSearchbarCustomEvent<SearchbarInputEventDetail>,

--- a/src/components/StudyView/StudyView.tsx
+++ b/src/components/StudyView/StudyView.tsx
@@ -47,6 +47,7 @@ const StudyView: React.FC<StudyViewProps> = ({ submissionId }) => {
   const { isOnline } = useNetworkStatus();
   const [modalTemplateVisibleSlots, setModalTemplateVisibleSlots] =
     React.useState<TemplateVisibleSlots | undefined>(undefined);
+  const [toursAllowed, setToursAllowed] = React.useState(false);
 
   const templateVisibleSlots = useMemo(() => {
     const fieldVisibilityInfo: TemplateVisibleSlots[] = [];
@@ -84,9 +85,11 @@ const StudyView: React.FC<StudyViewProps> = ({ submissionId }) => {
     for (const item of templateVisibleSlots) {
       if (item.visibleSlots === undefined) {
         setModalTemplateVisibleSlots(item);
+        setToursAllowed(false);
         return;
       }
     }
+    setToursAllowed(true);
   }, [modalTemplateVisibleSlots, templateVisibleSlots]);
 
   const handleSampleCreate = async (template: TemplateName) => {
@@ -268,6 +271,7 @@ const StudyView: React.FC<StudyViewProps> = ({ submissionId }) => {
           )}
 
           <SampleList
+            tourAllowed={toursAllowed}
             submission={submission.data}
             onSampleCreate={handleSampleCreate}
             sampleCreateFailureMessage={


### PR DESCRIPTION
Fixes #231 

The `StudyView` component conditionally launches on modal on data fetch. If it (or any components that it renders) starts a tour on view enter and the modal is opened soon after when the data fetch settles, the result is a tour highlighting an element that is hidden under the modal.

These changes address this by:

* Adding a prop to the `useAppTour` hook that allows a client to turn off initiating the tour on view enter
* Adding a return value from `useAppTour` that includes a function which can imperatively start the tour (or at least attempt to, depending on whether the tour has already been presented)
* Use an extra bit of state in `StudyView` to control whether it is safe to present tours. `StudyView` and its children can observe this state to imperatively start a tour when it's safe to do so.