### PR TITLE
Update icon inset to remove unsightly gap

### DIFF
--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background>
-        <inset android:drawable="@mipmap/ic_launcher_background" android:inset="16.7%" />
+        <inset android:drawable="@mipmap/ic_launcher_background" android:inset="16.6%" />
     </background>
     <foreground>
-        <inset android:drawable="@mipmap/ic_launcher_foreground" android:inset="16.7%" />
+        <inset android:drawable="@mipmap/ic_launcher_foreground" android:inset="16.6%" />
     </foreground>
 </adaptive-icon>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background>
-        <inset android:drawable="@mipmap/ic_launcher_background" android:inset="16.7%" />
+        <inset android:drawable="@mipmap/ic_launcher_background" android:inset="16.6%" />
     </background>
     <foreground>
-        <inset android:drawable="@mipmap/ic_launcher_foreground" android:inset="16.7%" />
+        <inset android:drawable="@mipmap/ic_launcher_foreground" android:inset="16.6%" />
     </foreground>
 </adaptive-icon>


### PR DESCRIPTION
Fixes #238

I can't say I truly understand what these changes are doing. I'm just following the workaround provided in https://github.com/ionic-team/capacitor-assets/issues/522. 

See #238 for the before. Here's the after:
<img width="149" alt="image" src="https://github.com/user-attachments/assets/d3713763-2539-4e9a-b835-0ed95da6c3c4" />

So it seems to work, and I didn't see any other adverse effects.