### PR TITLE
Add contact item to Settings tab

### DIFF
--- a/src/components/SettingsAboutList/SettingsAboutList.tsx
+++ b/src/components/SettingsAboutList/SettingsAboutList.tsx
@@ -13,6 +13,17 @@ const SettingsAboutList: React.FC = () => {
           </p>
         </IonLabel>
       </IonItem>
+      <IonItem
+        detail={false}
+        href={`mailto:${config.SUPPORT_EMAIL}`}
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <IonLabel>
+          <h3>Contact us</h3>
+          <p>Send an email with your comments or questions</p>
+        </IonLabel>
+      </IonItem>
     </IonList>
   );
 };

--- a/src/components/TourVisibilityManager/TourVisibilityManager.tsx
+++ b/src/components/TourVisibilityManager/TourVisibilityManager.tsx
@@ -21,7 +21,7 @@ const TourVisibilityManager: React.FC = () => {
 
   return (
     <>
-      <IonLabel onClick={handleResetClick} color={"primary"}>
+      <IonLabel onClick={handleResetClick}>
         <h3>Reset tours</h3>
         <p>Make the on-screen tours show up again</p>
       </IonLabel>

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,7 +72,8 @@ const config: Config = {
   /**
    * Support email address.
    */
-  SUPPORT_EMAIL: env.VITE_SUPPORT_EMAIL || "support@microbiomedata.org",
+  SUPPORT_EMAIL:
+    env.VITE_SUPPORT_EMAIL || "support+fieldnotes@microbiomedata.org",
 };
 
 export default config;


### PR DESCRIPTION
Fixes #242 

These changes add a "Contact us" item to the Settings tab. I confirmed that a `mailto:` link does open the default email app (GMail) on an Android simulator. iOS simulators [do not provide an email app](https://discussions.apple.com/thread/3830910?answerId=17959704022&sortBy=rank#17959704022); I trust it will work there as well but we'd need to test on a physical device.

I also changed the existing "Reset tours" item to the default color (it was the primary color). I think the intention was to show that that item was clickable. But we also had other interactive items that were _not_ the primary color. We'll always have a mix of interactive and non-interactive items, but I think I'd rather just be consistent with the colors.

Finally I updated the default value for the support email to be the plussed address we use elsewhere.