### PR TITLE
Fix slot selector modal presentation logic

### DIFF
--- a/src/components/SlotSelectorModal/SlotSelectorModal.tsx
+++ b/src/components/SlotSelectorModal/SlotSelectorModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import {
   IonButton,
   IonButtons,
@@ -98,6 +98,7 @@ const SlotSelectorModal: React.FC<SlotSelectorModalProps> = ({
   templateName,
 }) => {
   const [selectedSlots, setSelectedSlots] = React.useState<SlotName[]>([]);
+  const contentRef = useRef<HTMLIonContentElement | null>(null);
   const schema = useSubmissionSchema();
 
   const schemaClassName = templateName && TEMPLATES[templateName].schemaClass;
@@ -142,6 +143,11 @@ const SlotSelectorModal: React.FC<SlotSelectorModalProps> = ({
     }
   }, [isOpen, defaultSelectedSlots, slotGroups]);
 
+  // If the list of slots changes, scroll back to the top
+  useEffect(() => {
+    contentRef.current?.scrollToTop(0);
+  }, [slotGroups]);
+
   // When the user taps the Save button, translate the selected slots back into a list of hidden
   // slots and save them to the store. Then close the modal.
   const handleSave = () => {
@@ -171,7 +177,7 @@ const SlotSelectorModal: React.FC<SlotSelectorModalProps> = ({
           </IonButtons>
         </IonToolbar>
       </IonHeader>
-      <IonContent>
+      <IonContent ref={contentRef}>
         <div className="ion-padding nmdc-text-sm">
           Select the fields you would like to see when viewing and editing
           sample metadata for the <b>{templateDisplayName} template</b>.


### PR DESCRIPTION
Fixes #246 

The infinite loop of opening and closing the modal was caused by a bad interaction between the `useEffect` callback that attempts to open the modal when there are templates missing field visibility settings and the `onSuccess` callback called after the submission was updated with new field visibility settings that closes the modal. I believe the order of the `useEffect` call and the `onSuccess` call is not 100% deterministic, which is why there was initially a little confusion about how to reproduce the issue.

The fix here is to remove the `onSuccess` callback entirely. With these changes the `useEffect` callback is responsible for both opening _and_ closing the slot selector modal entirely based on the server data state. There is an added benefit here that the modal will now stay open until each template is processed instead of closing the modal and opening it again for the next template to process. 

Since the modal now stays open, however, it is now necessary to reset the scroll position when the slots it displays change. This is to prevent a confusing interaction where a user scrolls through the list of slots in the modal, taps save (which results in a new set of slots to show), and then they're looking at the middle of the new list.