### PR TITLE
Recommend bringing a stylus into the field (fixes #249)

### DIFF
--- a/src/pages/GuidePage/md/guide-page.md
+++ b/src/pages/GuidePage/md/guide-page.md
@@ -37,6 +37,7 @@ The NMDC Field Notes mobile app is designed to work with or without internet acc
 - Know risks for injuries in the sampling environment and be aware of the symptoms of common stress (e.g., heat exhaustion, frostbite, motion sickness) to mitigate injuries.
 - Bring plenty of food and water. Always bring more than you need.
 - Bring communication device(s) and know limitations of them (e.g., no cell phone service, finite battery life).
+- Bring a stylus in case you want to use a touchscreen while wearing gloves.
 - Bring a battery pack or energy bank if possible.
 - Wear or pack proper shoes and clothes for the environment and weather.
 - Only sample where you have permission to. Ensure you have all proper permits.


### PR DESCRIPTION
On this branch, I added a bullet point to the "Basic recommendations for fieldwork" section of the "Guide" screen (that is the section that already contained things like "Bring sunscreen..." and "Bring a battery pack..."). The new bullet point says:
- Bring a stylus in case you want to use a touchscreen while wearing gloves.

In the bullet point, I mentioned gloves as an example use case. In reality, a stylus can be used without gloves also (e.g. when one's hands are wet or dirty).