### PR TITLE
Align submission data model with backend

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -54,20 +54,34 @@ export interface StudyForm {
   piName: string;
   piEmail: string;
   piOrcid: string;
+  fundingSources: Nullable<string[]>;
   linkOutWebpage: string[];
   studyDate: Nullable<string>;
   description: string;
   notes: string;
   contributors: Contributor[];
+  alternativeNames: string[];
+  GOLDStudyId: string;
+  NCBIBioProjectId: string;
 }
 
 export interface MultiOmicsForm {
-  alternativeNames: string[];
-  studyNumber: string;
-  GOLDStudyId: string;
+  award: Nullable<string>;
+  awardDois: Nullable<string[]>;
+  dataGenerated: Nullable<boolean>;
+  doe: Nullable<boolean>;
+  facilities: string[];
+  facilityGenerated: Nullable<boolean>;
   JGIStudyId: string;
-  NCBIBioProjectId: string;
+  mgCompatible: Nullable<boolean>;
+  mgInterleaved: Nullable<boolean>;
+  mtCompatible: Nullable<boolean>;
+  mtInterleaved: Nullable<boolean>;
   omicsProcessingTypes: string[];
+  otherAward: Nullable<string>;
+  ship: Nullable<boolean>;
+  studyNumber: string;
+  unknownDoi: Nullable<boolean>;
 }
 
 export type SampleDataValue =
@@ -157,8 +171,7 @@ export type TemplateName = keyof typeof TEMPLATES;
 export type SlotName = string;
 
 export interface MetadataSubmission {
-  packageName: TemplateName | TemplateName[] | "";
-  contextForm: ContextForm;
+  packageName: TemplateName[];
   addressForm: AddressForm;
   templates: string[];
   studyForm: StudyForm;

--- a/src/components/StudyForm/StudyForm.tsx
+++ b/src/components/StudyForm/StudyForm.tsx
@@ -257,7 +257,7 @@ const StudyForm: React.FC<StudyFormProps> = ({
                 data-tour={`${TourId.StudyForm}-2`}
                 className={`${(fieldState.isTouched || formState.isSubmitted) && "ion-touched"} ${fieldState.invalid && "ion-invalid"}`}
                 labelPlacement="floating"
-                multiple={Array.isArray(field.value)}
+                multiple
                 onIonDismiss={field.onBlur}
                 onIonChange={(e) => {
                   // The `packageName` and `templates` fields need to stay in sync.
@@ -265,32 +265,20 @@ const StudyForm: React.FC<StudyFormProps> = ({
                     "metadata_submission.packageName",
                   );
                   const newPackageName = e.detail.value;
-                  // The value of the `packageName` field is typed to be a string or an array of
-                  // strings to ease the transition between the formats that the backend accepts.
-                  // Once the transition is complete, this logic can be simplified to only use
-                  // the array format.
-                  if (typeof previousPackageName === "string") {
-                    // If the previous value was a string, just replace the first element of
-                    // the templates array with the new package name.
-                    setValue("metadata_submission.templates.0", newPackageName);
-                  } else if (Array.isArray(previousPackageName)) {
-                    // If the previous value was a string, remove all the previous package names
-                    // from the templates array and prepend the new package names.
-                    const templates = getValues(
-                      "metadata_submission.templates",
-                    );
-                    setValue(
-                      "metadata_submission.templates",
-                      newPackageName.concat(
-                        templates.filter(
-                          (template) =>
-                            !previousPackageName.includes(
-                              template as TemplateName,
-                            ),
-                        ),
+                  // Remove all the previous package names from the templates array and prepend the
+                  // new package names.
+                  const templates = getValues("metadata_submission.templates");
+                  setValue(
+                    "metadata_submission.templates",
+                    newPackageName.concat(
+                      templates.filter(
+                        (template) =>
+                          !previousPackageName.includes(
+                            template as TemplateName,
+                          ),
                       ),
-                    );
-                  }
+                    ),
+                  );
                   field.onChange(newPackageName);
                 }}
                 {...field}

--- a/src/data.ts
+++ b/src/data.ts
@@ -54,20 +54,33 @@ export const initStudyForm = (): StudyForm => ({
   studyDate: undefined,
   studyName: "",
   notes: "",
+  fundingSources: [],
+  alternativeNames: [],
+  GOLDStudyId: "",
+  NCBIBioProjectId: "",
 });
 
 export const initMultiOmicsForm = (): MultiOmicsForm => ({
-  GOLDStudyId: "",
+  award: undefined,
+  awardDois: undefined,
+  dataGenerated: undefined,
+  doe: undefined,
+  facilities: [],
+  facilityGenerated: undefined,
   JGIStudyId: "",
-  NCBIBioProjectId: "",
-  alternativeNames: [],
+  mgCompatible: undefined,
+  mgInterleaved: undefined,
+  mtCompatible: undefined,
+  mtInterleaved: undefined,
   omicsProcessingTypes: [],
+  otherAward: undefined,
+  ship: undefined,
   studyNumber: "",
+  unknownDoi: undefined,
 });
 
 export const initMetadataSubmission = (): MetadataSubmission => ({
   addressForm: initAddressForm(),
-  contextForm: initContextForm(),
   multiOmicsForm: initMultiOmicsForm(),
   packageName: [],
   sampleData: {},

--- a/src/mocks/fixtures.ts
+++ b/src/mocks/fixtures.ts
@@ -1,5 +1,5 @@
 import { FetchClient, SubmissionMetadata } from "../api";
-import { initAddressForm, initContextForm, initMultiOmicsForm } from "../data";
+import { initAddressForm, initMultiOmicsForm, initStudyForm } from "../data";
 import config from "../config";
 
 export function generateSubmission(
@@ -17,22 +17,11 @@ export function generateSubmission(
     created: "2021-01-01T00:00:00Z",
     author_orcid: "0000-0000-0000-0000",
     metadata_submission: {
-      packageName: "soil",
+      packageName: ["soil"],
       multiOmicsForm: initMultiOmicsForm(),
-      contextForm: initContextForm(),
       addressForm: initAddressForm(),
       templates: ["soil"],
-      studyForm: {
-        studyName: "",
-        piName: "",
-        piEmail: "",
-        piOrcid: "",
-        linkOutWebpage: [],
-        studyDate: undefined,
-        description: "",
-        contributors: [],
-        notes: "",
-      },
+      studyForm: initStudyForm(),
       sampleData: {
         soil_data: Array.from({ length: numberOfSamples }, (_, i) => ({
           samp_name:
@@ -53,7 +42,7 @@ export function generateSubmission(
 export const submissions: () => SubmissionMetadata[] = () => [
   {
     metadata_submission: {
-      packageName: "soil",
+      packageName: ["host-associated", "soil"],
       contextForm: {
         datasetDoi: "",
         dataGenerated: false,
@@ -86,7 +75,7 @@ export const submissions: () => SubmissionMetadata[] = () => [
         irbOrHipaa: null,
         comments: "",
       },
-      templates: ["host-associated"],
+      templates: ["host-associated", "soil"],
       studyForm: {
         studyName: "TEST 1",
         piName: "",
@@ -97,15 +86,12 @@ export const submissions: () => SubmissionMetadata[] = () => [
         description: "",
         notes: "",
         contributors: [],
-      },
-      multiOmicsForm: {
         alternativeNames: [],
-        studyNumber: "",
+        fundingSources: [],
         GOLDStudyId: "",
-        JGIStudyId: "",
         NCBIBioProjectId: "",
-        omicsProcessingTypes: [],
       },
+      multiOmicsForm: initMultiOmicsForm(),
       sampleData: {
         soil_data: [],
         host_associated_data: [],
@@ -127,7 +113,7 @@ export const submissions: () => SubmissionMetadata[] = () => [
   },
   {
     metadata_submission: {
-      packageName: "host-associated",
+      packageName: ["host-associated", "soil"],
       contextForm: {
         datasetDoi: "",
         dataGenerated: false,
@@ -160,7 +146,7 @@ export const submissions: () => SubmissionMetadata[] = () => [
         irbOrHipaa: null,
         comments: "",
       },
-      templates: ["host-associated"],
+      templates: ["host-associated", "soil"],
       studyForm: {
         studyName: "TEST 2",
         piName: "",
@@ -171,15 +157,12 @@ export const submissions: () => SubmissionMetadata[] = () => [
         description: "",
         notes: "",
         contributors: [],
-      },
-      multiOmicsForm: {
         alternativeNames: [],
-        studyNumber: "",
+        fundingSources: [],
         GOLDStudyId: "",
-        JGIStudyId: "",
         NCBIBioProjectId: "",
-        omicsProcessingTypes: [],
       },
+      multiOmicsForm: initMultiOmicsForm(),
       sampleData: {
         soil_data: [],
         host_associated_data: [],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,10 +5,6 @@ import { SlotDefinition } from "./linkml-metamodel";
 /**
  * Get the templates associated with a submission.
  *
- * This function is mainly useful to ease the transition between the old format where the
- * `packageName` field was a string and the new format where it is an array of strings.
- * This function always returns an array of strings.
- *
  * @param submission
  */
 export function getSubmissionTemplates(
@@ -18,13 +14,6 @@ export function getSubmissionTemplates(
     return [];
   }
   const { packageName } = submission.metadata_submission;
-  if (typeof packageName === "string") {
-    if (packageName === "") {
-      return [];
-    } else {
-      return [packageName];
-    }
-  }
   return packageName;
 }
 


### PR DESCRIPTION
Fixes #255 

### Summary

* Align the Typescript definitions of the submission data format with the [backend data model](https://github.com/microbiomedata/nmdc-server/blob/main/nmdc_server/schemas_submission.py).
* Remove some old workaround to allow the `packageName` field to either be a single string or an array of strings. This value is always an array of strings now.