### PR TITLE
Use `MutationErrorBoundary` to show error if study creation fails

### DIFF
--- a/src/pages/StudyCreatePage/StudyCreatePage.tsx
+++ b/src/pages/StudyCreatePage/StudyCreatePage.tsx
@@ -19,6 +19,7 @@ import { useNetworkStatus } from "../../NetworkStatus";
 import FixedCenteredMessage from "../../components/FixedCenteredMessage/FixedCenteredMessage";
 import useNavigateWithState from "../../useNavigateWithState";
 import { logStudyCreatedEvent } from "../../analytics";
+import MutationErrorBanner from "../../components/MutationErrorBanner/MutationErrorBanner";
 
 const StudyCreatePage: React.FC = () => {
   const navigate = useNavigateWithState();
@@ -55,6 +56,9 @@ const StudyCreatePage: React.FC = () => {
         </ThemedToolbar>
       </IonHeader>
       <IonContent>
+        <MutationErrorBanner mutation={submissionCreate}>
+          Error saving study
+        </MutationErrorBanner>
         {isOnline ? (
           <StudyForm submission={submission} onSave={handleSave} />
         ) : (


### PR DESCRIPTION
Fixes #234 

Does what it says on the tin: use the existing `MutationErrorBoundary` component to show an error message if study creation fails. 

I also did a quick survey of other mutation hooks to see if we were missing any other `MutationErrorBoundary` usage, and I didn't see any. Caveat: some lock/unlock mutations are intentionally not piped to a `MutationErrorBoundary` because if they fail there will a "you don't have the lock" error when the subsequent update mutation goes out and we catch/display _that_ error.