### PR TITLE
Fix layout bug causing "Logging in" message to appear at top of screen

### DIFF
--- a/src/pages/TokenPage/TokenPage.tsx
+++ b/src/pages/TokenPage/TokenPage.tsx
@@ -4,6 +4,7 @@ import { useStore } from "../../Store";
 import paths from "../../paths";
 import {
   IonCol,
+  IonContent,
   IonGrid,
   IonPage,
   IonRow,
@@ -58,24 +59,26 @@ const TokenPage: React.FC = () => {
 
   return (
     <IonPage>
-      <FixedCenteredMessage>
-        {loginError ? (
-          <IonText>There was an error logging you in</IonText>
-        ) : (
-          <IonGrid>
-            <IonRow>
-              <IonCol>
-                <IonSpinner />
-              </IonCol>
-            </IonRow>
-            <IonRow>
-              <IonCol>
-                <IonText>Logging in...</IonText>
-              </IonCol>
-            </IonRow>
-          </IonGrid>
-        )}
-      </FixedCenteredMessage>
+      <IonContent fullscreen>
+        <FixedCenteredMessage>
+          {loginError ? (
+            <IonText>There was an error logging you in</IonText>
+          ) : (
+            <IonGrid>
+              <IonRow>
+                <IonCol>
+                  <IonSpinner />
+                </IonCol>
+              </IonRow>
+              <IonRow>
+                <IonCol>
+                  <IonText>Logging in...</IonText>
+                </IonCol>
+              </IonRow>
+            </IonGrid>
+          )}
+        </FixedCenteredMessage>
+      </IonContent>
     </IonPage>
   );
 };


### PR DESCRIPTION
On this branch, I fixed a layout bug that was causing the "Logging in" message to appear at the top of the screen instead of in the middle of the screen.

The fix was to wrap everything in an `<IonContent>` tag with a `fullscreen` prop, as shown in the diff.

Here's a screenshot showing the resulting layout (note: this screenshot has some unrelated blurring at the top of the device, since I was originally planning to post a video and wanted to blur the URLs being visited during the login flow).

<img width="1038" height="587" alt="image" src="https://github.com/user-attachments/assets/3fb3d4a9-5fdd-4185-9fb3-eb0b6787e9c5" />
