### PR TITLE
Update `Info.plist` permissions for upgraded `@capacitor/geolocation` plugin

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -26,6 +26,8 @@
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Your location can be used for filling out sample metadata</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Your location can be used for filling out sample metadata</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/ios/App/App_Prod-Info.plist
+++ b/ios/App/App_Prod-Info.plist
@@ -26,6 +26,8 @@
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Your location can be used for filling out sample metadata</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Your location can be used for filling out sample metadata</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
Fixes #271 

After making this change I tested the "use GPS" button on an iOS simulator device and it appeared to work. We should still definitely test on a physical device after releasing to TestFlight.